### PR TITLE
Update goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,8 @@
 project_name: dbtcloud-terraforming
 builds:
   - main: ./cmd/dbtcloud-terraforming/main.go
+    ldflags:
+      - -s -w -X "github.com/dbt-labs/dbtcloud-terraforming/internal/app/dbtcloud-terraforming/cmd.versionString={{.Env.VERSION}}"
     env:
       - CGO_ENABLED=0
     goos:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # dbt Cloud Terraforming
 
+`dbtcloud-terraforming` has been created to be used along with the [dbt Cloud Terraform provider](https://registry.terraform.io/providers/dbt-labs/dbtcloud/latest) maintained by dbt Labs.
+
+It can be used to generate the relevant Terraform configuration files based on existing dbt Cloud configuration.
+
 ```sh
 dbtcloud-terraforming is an application that allows dbt Cloud users
 to be able to adopt Terraform by giving them a feasible way to get
@@ -65,6 +69,13 @@ Notes:
 
 ## How to use the tool
 
+### Installation
+
+Download the executable for your platform [from the GitHUb releases page](https://github.com/dbt-labs/dbtcloud-terraforming/releases/tag/v0.2.0) and extract it.
+You can then add it to your PATH and run it with `dbtcloud-terraforming` or run it based on its location (e.g. `./dbtcloud-terraforming`).
+
+(WIP) There will soon be the ability to install the CLI from `homebrew` for MacOS and Linux.
+
 ### Connecting to dbt Cloud
 
 To connect to dbt Cloud, you need to provide an API token and a dbt Cloud Account ID. If your account is not hosted on cloud.getdbt.com you will also need to provide the relevant API endpoint.
@@ -79,6 +90,14 @@ Example:
 export DBT_CLOUD_TOKEN=<token>
 export DBT_CLOUD_ACCOUNT_ID=123
 export DBT_CLOUD_HOST_URL="http://emea.dbt.com/api"
+```
+
+or for Powershell
+
+```sh
+$Env:DBT_CLOUD_TOKEN = '<token>'
+$Env:DBT_CLOUD_ACCOUNT_ID = 123
+$Env:DBT_CLOUD_HOST_URL = 'http://emea.dbt.com/api'
 ```
 
 ### Executing the tool
@@ -126,6 +145,10 @@ dbtcloud-terraforming generate --resource-types dbcloud_project,dbtcloud_environ
 - and the dbt Cloud jobs will be linked to both their relevant project and environment
 
 This can be especially useful if you want to replicate an existing project. To do so, you can generate all the config *without* importing it. You could change the name of a project, and after running a `terraform apply` all the objects will be newly created, replicating your existing config in another project.
+
+## Contributing
+
+Currently, the best way to contribute is to raise bugs/feature requests as GitHub issues.
 
 ## Credits
 

--- a/cmd/dbtcloud-terraforming/main.go
+++ b/cmd/dbtcloud-terraforming/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/dbt-cloud/dbtcloud-terraforming/internal/app/dbtcloud-terraforming/cmd"
+	"github.com/dbt-labs/dbtcloud-terraforming/internal/app/dbtcloud-terraforming/cmd"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dbt-cloud/dbtcloud-terraforming
+module github.com/dbt-labs/dbtcloud-terraforming
 
 go 1.21.0
 

--- a/internal/app/dbtcloud-terraforming/cmd/generate_test.go
+++ b/internal/app/dbtcloud-terraforming/cmd/generate_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/MakeNowJust/heredoc/v2"
-	"github.com/dbt-cloud/dbtcloud-terraforming/dbtcloud"
+	"github.com/dbt-labs/dbtcloud-terraforming/dbtcloud"
 	"gopkg.in/dnaeon/go-vcr.v3/cassette"
 	"gopkg.in/dnaeon/go-vcr.v3/recorder"
 

--- a/internal/app/dbtcloud-terraforming/cmd/import_test.go
+++ b/internal/app/dbtcloud-terraforming/cmd/import_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/dbt-cloud/dbtcloud-terraforming/dbtcloud"
+	"github.com/dbt-labs/dbtcloud-terraforming/dbtcloud"
 	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/samber/lo"
 	"github.com/spf13/viper"

--- a/internal/app/dbtcloud-terraforming/cmd/root.go
+++ b/internal/app/dbtcloud-terraforming/cmd/root.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/dbt-cloud/dbtcloud-terraforming/dbtcloud"
+	"github.com/dbt-labs/dbtcloud-terraforming/dbtcloud"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/internal/app/dbtcloud-terraforming/cmd/util.go
+++ b/internal/app/dbtcloud-terraforming/cmd/util.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/dbt-cloud/dbtcloud-terraforming/dbtcloud"
+	"github.com/dbt-labs/dbtcloud-terraforming/dbtcloud"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	tfjson "github.com/hashicorp/terraform-json"


### PR DESCRIPTION
- update `goreleaser` to add the CLI version
- add installation instructions
- link to the dbtcloud Terraform provider