### PR TITLE
fix: exclude default groups (Owner/Member/Everyone) from dbtcloud_user_groups references

### DIFF
--- a/internal/app/dbtcloud-terraforming/cmd/generate.go
+++ b/internal/app/dbtcloud-terraforming/cmd/generate.go
@@ -47,6 +47,52 @@ type tfVar struct {
 var AllTFVars = []tfVar{}
 var AllLocals = map[string]string{}
 
+// defaultGroups are the built-in dbt platform groups that are never generated
+// as dbtcloud_group resources (their membership is managed by dbt platform
+// itself, not Terraform). Any other resource that references groups (e.g.
+// dbtcloud_user_groups) must exclude these from its output to avoid dangling
+// references to resources that are never created.
+var defaultGroups = []string{"Owner", "Member", "Everyone"}
+
+// buildGroupIDToNameMap indexes a list of raw group payloads (as returned by
+// dbtCloudClient.GetGroups()) by their numeric ID, so callers can resolve a
+// group ID to its name (e.g. to check whether it's a default group).
+func buildGroupIDToNameMap(listGroups []any) map[int]string {
+	groupIDToName := map[int]string{}
+	for _, group := range listGroups {
+		groupTyped := group.(map[string]any)
+		groupIDToName[int(groupTyped["id"].(float64))] = groupTyped["name"].(string)
+	}
+	return groupIDToName
+}
+
+// isDefaultGroupID reports whether groupID resolves (via groupIDToName) to
+// one of the built-in default groups (Owner/Member/Everyone). If the ID
+// isn't found in the map, it is treated as not default.
+func isDefaultGroupID(groupID int, groupIDToName map[int]string) bool {
+	name, ok := groupIDToName[groupID]
+	if !ok {
+		return false
+	}
+	return lo.Contains(defaultGroups, name)
+}
+
+// filterOutDefaultGroupIDs returns groupIDs with any built-in default group
+// (Owner/Member/Everyone) removed. Those groups are never generated as
+// dbtcloud_group resources, so any resource referencing group IDs must
+// exclude them to avoid dangling references (when linked) or attempting to
+// manage membership dbt platform itself controls (when not linked).
+func filterOutDefaultGroupIDs(groupIDs []int, groupIDToName map[int]string) []int {
+	filtered := []int{}
+	for _, groupID := range groupIDs {
+		if isDefaultGroupID(groupID, groupIDToName) {
+			continue
+		}
+		filtered = append(filtered, groupID)
+	}
+	return filtered
+}
+
 func linkResource(resourceType string) bool {
 	if len(listLinkedResources) == 0 {
 		return false
@@ -716,8 +762,6 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 				for _, group := range listGroups {
 					groupTyped := group.(map[string]any)
 
-					defaultGroups := []string{"Owner", "Member", "Everyone"}
-
 					// we check if the group is one of the default ones
 					_, ok := lo.Find(defaultGroups, func(i string) bool {
 						return i == groupTyped["name"].(string)
@@ -752,6 +796,16 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 			case "dbtcloud_user_groups":
 				listUsers := dbtCloudClient.GetUsers()
 
+				// we need the group names so we can exclude the built-in
+				// default groups (Owner/Member/Everyone) from group_ids:
+				// those groups are never generated as dbtcloud_group
+				// resources, so referencing them here (or even including
+				// their raw IDs) would either produce dangling resource
+				// references or manage membership that dbt platform itself
+				// controls.
+				listGroups := dbtCloudClient.GetGroups()
+				groupIDToName := buildGroupIDToNameMap(listGroups)
+
 				for _, user := range listUsers {
 					userTyped := user.(map[string]any)
 
@@ -773,12 +827,27 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 
 					userPermissionsArray := userTyped["permissions"].([]any)
 					userPermissions := userPermissionsArray[0].(map[string]any)
-					groupIDs := []int{}
+					allGroupIDs := []int{}
 
 					for _, group := range userPermissions["groups"].([]any) {
 						groupTyped := group.(map[string]any)
-						groupIDs = append(groupIDs, int(groupTyped["id"].(float64)))
+						allGroupIDs = append(allGroupIDs, int(groupTyped["id"].(float64)))
 					}
+
+					// exclude the built-in default groups: they are never
+					// generated as dbtcloud_group resources, so keeping them
+					// here would produce dangling references (when linked)
+					// or manage membership dbt platform already controls
+					// (when not linked).
+					groupIDs := filterOutDefaultGroupIDs(allGroupIDs, groupIDToName)
+
+					// if the user has no non-default groups left, there is
+					// nothing for this resource to manage, so we skip it
+					// entirely instead of emitting an empty/pointless block.
+					if len(groupIDs) == 0 {
+						continue
+					}
+
 					userTyped["group_ids"] = groupIDs
 
 					if linkResource("dbtcloud_group") {

--- a/internal/app/dbtcloud-terraforming/cmd/generate_test.go
+++ b/internal/app/dbtcloud-terraforming/cmd/generate_test.go
@@ -93,6 +93,14 @@ func TestResourceGeneration(t *testing.T) {
 		"dbt Cloud projects":     {identifierType: "account", resourceType: "dbtcloud_project", testdataFilename: "dbtcloud_project"},
 		"dbt Cloud jobs":         {identifierType: "account", resourceType: "dbtcloud_job", testdataFilename: "dbtcloud_job"},
 		"dbt Cloud repositories": {identifierType: "account", resourceType: "dbtcloud_repository", testdataFilename: "dbtcloud_repository"},
+		// NOTE: the "dbtcloud_user_groups" cassette (testdata/dbtcloud/dbtcloud_user_groups.yaml)
+		// has not been recorded yet - recording it requires live account credentials via:
+		//   OVERWRITE_VCR_CASSETTES=true go test ./internal/app/dbtcloud-terraforming/cmd/... \
+		//     -run TestResourceGeneration/dbt_Cloud_user_groups -v
+		// Until that cassette exists, this row is scaffolded but will fail if run; see
+		// TestGenerate_FilterOutDefaultGroupIDs and TestGenerate_UserGroupsHCLExcludesDefaultGroups
+		// for standalone unit coverage of the default-group filtering fix in the meantime.
+		"dbt Cloud user groups": {identifierType: "account", resourceType: "dbtcloud_user_groups", testdataFilename: "dbtcloud_user_groups"},
 	}
 
 	for name, tc := range tests {
@@ -165,4 +173,139 @@ func TestResourceGeneration(t *testing.T) {
 			assert.Equal(t, strings.TrimRight(expected, "\n"), strings.TrimRight(output, "\n"))
 		})
 	}
+}
+
+// fabricatedGroupsPayload mimics the shape returned by
+// dbtCloudClient.GetGroups(): a mix of built-in default groups
+// (Owner/Member/Everyone) and custom, user-managed groups.
+func fabricatedGroupsPayload() []any {
+	return []any{
+		map[string]any{"id": float64(1), "name": "Owner"},
+		map[string]any{"id": float64(2), "name": "Member"},
+		map[string]any{"id": float64(3), "name": "Everyone"},
+		map[string]any{"id": float64(10), "name": "Analysts"},
+		map[string]any{"id": float64(11), "name": "Admins"},
+	}
+}
+
+// TestGenerate_FilterOutDefaultGroupIDs unit tests the helper functions used
+// by the "dbtcloud_user_groups" case to exclude the built-in default groups
+// (Owner/Member/Everyone) from group_ids. Those groups are deliberately
+// skipped by the "dbtcloud_group" case, so any resource that still
+// references their IDs would produce dangling `dbtcloud_group` resource
+// references once linked, causing `terraform plan`/`validate` to fail with
+// "Reference to undeclared resource".
+func TestGenerate_FilterOutDefaultGroupIDs(t *testing.T) {
+	groupIDToName := buildGroupIDToNameMap(fabricatedGroupsPayload())
+
+	tests := map[string]struct {
+		groupIDs []int
+		want     []int
+	}{
+		"mix of default and custom groups keeps only custom ones": {
+			groupIDs: []int{1, 2, 3, 10, 11},
+			want:     []int{10, 11},
+		},
+		"only default groups results in an empty list": {
+			groupIDs: []int{1, 2, 3},
+			want:     []int{},
+		},
+		"only custom groups are left untouched": {
+			groupIDs: []int{10, 11},
+			want:     []int{10, 11},
+		},
+		"unknown group id (not in the account's groups) is kept": {
+			groupIDs: []int{999},
+			want:     []int{999},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := filterOutDefaultGroupIDs(tc.groupIDs, groupIDToName)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestGenerate_UserGroupsHCLExcludesDefaultGroups asserts, at the HCL output
+// level, that the "dbtcloud_user_groups" logic:
+//  1. Only emits custom (non-default) group IDs in `group_ids`.
+//  2. Emits no attribute/block at all for a user who is only a member of
+//     default groups once those are filtered out (nothing left to manage).
+//
+// This mirrors how TestGenerate_writeAttrLine asserts on generated HCL
+// output in this file, applied to the group_ids filtering added to fix the
+// dangling default-group reference bug.
+func TestGenerate_UserGroupsHCLExcludesDefaultGroups(t *testing.T) {
+	groupIDToName := buildGroupIDToNameMap(fabricatedGroupsPayload())
+
+	// fabricated users-with-groups payload: user 1 belongs to a mix of
+	// default and custom groups, user 2 belongs only to default groups.
+	fabricatedUsers := []any{
+		map[string]any{
+			"id": float64(100),
+			"permissions": []any{
+				map[string]any{
+					"groups": []any{
+						map[string]any{"id": float64(1)},  // Owner (default)
+						map[string]any{"id": float64(2)},  // Member (default)
+						map[string]any{"id": float64(10)}, // Analysts (custom)
+						map[string]any{"id": float64(11)}, // Admins (custom)
+					},
+				},
+			},
+		},
+		map[string]any{
+			"id": float64(200),
+			"permissions": []any{
+				map[string]any{
+					"groups": []any{
+						map[string]any{"id": float64(1)}, // Owner (default)
+						map[string]any{"id": float64(3)}, // Everyone (default)
+					},
+				},
+			},
+		},
+	}
+
+	var renderedBlocks []string
+
+	for _, user := range fabricatedUsers {
+		userTyped := user.(map[string]any)
+
+		userPermissionsArray := userTyped["permissions"].([]any)
+		userPermissions := userPermissionsArray[0].(map[string]any)
+		allGroupIDs := []int{}
+		for _, group := range userPermissions["groups"].([]any) {
+			groupTyped := group.(map[string]any)
+			allGroupIDs = append(allGroupIDs, int(groupTyped["id"].(float64)))
+		}
+
+		groupIDs := filterOutDefaultGroupIDs(allGroupIDs, groupIDToName)
+
+		// mirrors the "omit the resource entirely if nothing is left to
+		// manage" behavior in the generate.go "dbtcloud_user_groups" case.
+		if len(groupIDs) == 0 {
+			continue
+		}
+
+		f := hclwrite.NewEmptyFile()
+		writeAttrLine("group_ids", groupIDs, "", f.Body())
+		renderedBlocks = append(renderedBlocks, string(f.Bytes()))
+	}
+
+	// Only one block should have been rendered (for user 100); user 200 had
+	// nothing but default groups and must produce no resource at all.
+	assert.Len(t, renderedBlocks, 1)
+	assert.Equal(t, "group_ids = [10, 11]\n", renderedBlocks[0])
+
+	fullOutput := strings.Join(renderedBlocks, "")
+	assert.NotContains(t, fullOutput, "= [1,")
+	assert.NotContains(t, fullOutput, ", 1,")
+	assert.NotContains(t, fullOutput, ", 1]")
+	assert.NotContains(t, fullOutput, "= [2,")
+	assert.NotContains(t, fullOutput, ", 2]")
+	assert.NotContains(t, fullOutput, "= [3,")
+	assert.NotContains(t, fullOutput, ", 3]")
 }


### PR DESCRIPTION
## Problem
  `dbtcloud_user_groups.group_ids` linked every group ID on a user's permission
  set to `dbtcloud_group.terraform_managed_resource_<id>.id` — including the
  built-in `Owner`/`Member`/`Everyone` groups. Those groups are deliberately
  never generated as `dbtcloud_group` resources (their membership is managed by
  dbt platform itself, not Terraform), so linked output produced dangling
  references and `terraform plan`/`validate` failed with "Reference to
  undeclared resource".

  ## Fix
  - Hoisted `defaultGroups` to a shared package-level var so both the
    `dbtcloud_group` and `dbtcloud_user_groups` cases use one source of truth.
  - Resolve each user's group IDs to names and filter out the built-in defaults
    before building both the raw and linked `group_ids` values.
  - If a user has zero groups left after filtering, the `dbtcloud_user_groups`
    resource is omitted for that user entirely instead of emitting an empty
    block.

  ## Testing
  - `TestGenerate_FilterOutDefaultGroupIDs` — unit coverage of the new
    filtering helpers.
  - `TestGenerate_UserGroupsHCLExcludesDefaultGroups` — asserts on rendered HCL
    that default groups are excluded and all-default users produce no block.
  - `go build`, `go vet`, `gofmt -l` clean.
  - A `dbtcloud_user_groups` row was scaffolded in `TestResourceGeneration`;
    its VCR cassette is **not yet recorded** (needs live account creds) — see
    the code comment at that row for the exact recording command.

  Repo has no CI, so verification output is included directly:
```
  $ go build ./...      # clean
  $ go vet ./...         # clean
  $ gofmt -l .           # clean

  $ go test ./internal/app/dbtcloud-terraforming/cmd/... -run \
      'TestGenerate_writeAttrLine|TestGenerate_FilterOutDefaultGroupIDs|TestGenerate_UserGroupsHCLExcludesDefaultGroups' -v

  --- PASS: TestGenerate_writeAttrLine (0.00s)
      --- PASS: TestGenerate_writeAttrLine/value_is_block_of_strings (0.00s)
      --- PASS: TestGenerate_writeAttrLine/value_is_nil (0.00s)
      --- PASS: TestGenerate_writeAttrLine/value_is_string (0.00s)
      --- PASS: TestGenerate_writeAttrLine/value_is_int (0.00s)
      --- PASS: TestGenerate_writeAttrLine/value_is_float (0.00s)
      --- PASS: TestGenerate_writeAttrLine/value_is_bool (0.00s)
      --- PASS: TestGenerate_writeAttrLine/value_is_list_of_strings (0.00s)
  --- PASS: TestGenerate_FilterOutDefaultGroupIDs (0.00s)
      --- PASS: TestGenerate_FilterOutDefaultGroupIDs/mix_of_default_and_custom_groups_keeps_only_custom_ones (0.00s)
      --- PASS: TestGenerate_FilterOutDefaultGroupIDs/only_default_groups_results_in_an_empty_list (0.00s)
      --- PASS: TestGenerate_FilterOutDefaultGroupIDs/only_custom_groups_are_left_untouched (0.00s)
      --- PASS: TestGenerate_FilterOutDefaultGroupIDs/unknown_group_id_(not_in_the_account's_groups)_is_kept (0.00s)
  --- PASS: TestGenerate_UserGroupsHCLExcludesDefaultGroups (0.00s)
  PASS
  ok    github.com/dbt-labs/dbtcloud-terraforming/internal/app/dbtcloud-terraforming/cmd        (cached)
```
  A `dbtcloud_user_groups` row was scaffolded in `TestResourceGeneration`; its
  VCR cassette is **not yet recorded** (needs live account creds) — see the
  code comment at that row for the exact recording command. Note the
  pre-existing `TestResourceGeneration` suite fails on its first row
  (`dbt Cloud projects`) in any local environment without `DBT_CLOUD_ACCOUNT_ID`
  set and recorded fixtures present — this is unrelated to this change and
  reproduces identically on the unmodified base branch.

  ## Out of scope
  `dbtcloud_group` definition behavior and SCIM/partial-permission group
  resources.