### PR TITLE
Feat/id generalization acct feat

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,14 @@ This tool can be used to load existing dbt Cloud configuration into Terraform. C
 | dbtcloud_databricks_credential                            | Project        | ✅                 | ✅               | 🔒                    |
 | dbtcloud_environment                                      | Project        | ✅                 | ✅               |                       |
 | dbtcloud_environment_variable                             | Project        | ✅                 | ✅               | 🔒*                  |
-| dbtcloud_environment_variable_job_override                | Project        |                    |                  |                       |
+| dbtcloud_environment_variable_job_override                | Project        | ✅                 | ✅               | 🔒*                  |
 | dbtcloud_extended_attributes(*)                           | Project        | ✅                 | ✅               |                       |
 | dbtcloud_fabric_connection                                | Project        |                    |                  |                       |
 | dbtcloud_fabric_credential                                | Project        |                    |                  | 🔒                   |
 | dbtcloud_global_connection                                | Account        | ✅                 | ✅               | 🔒*                   |
 | dbtcloud_group                                            | Account        | ✅                 | ✅               |                       |
 | dbtcloud_job                                              | Project        | ✅                 | ✅               |                       |
+| dbtcloud_job_completion_trigger                           | Project        | ✅                 | ✅               |                       |
 | dbtcloud_license_map                                      | Account        |                    |                  |                       |
 | dbtcloud_notification                                     | Account        | ✅                 | ✅               |                       |
 | dbtcloud_postgres_credential                              | Project        |                    |                  | 🔒*                  |

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This tool can be used to load existing dbt Cloud configuration into Terraform. C
 | dbtcloud_license_map                                      | Account        |                    |                  |                       |
 | dbtcloud_notification                                     | Account        | ✅                 | ✅               |                       |
 | dbtcloud_postgres_credential                              | Project        |                    |                  | 🔒*                  |
+| dbtcloud_profile                                          | Project        | ✅                 | ✅               |                       |
 | dbtcloud_project                                          | Project        | ✅                 | ✅               |                       |
 | dbtcloud_project_artefacts (deprecated)                   | Project        | ❌                 | ❌               |                       |
 | dbtcloud_project_connection (deprecated)                  | Project        | ❌                 | ❌               |                       |

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This tool can be used to load existing dbt Cloud configuration into Terraform. C
 
 | Resource                                                  | Resource Scope | Generate Supported | Import Supported | Requires manual setup |
 | --------------------------------------------------------- | -------------- | ------------------ | ---------------- | --------------------- |
+| dbtcloud_account_features                                 | Account        | ✅                 | ✅               |                       |
 | dbtcloud_bigquery_connection (use glob conn if possible)  | Project        | ✅                 | ✅               | 🔒                   |
 | dbtcloud_bigquery_credential                              | Project        | ✅                 | ✅               |                       |
 | dbtcloud_connection (use glob conn if possible)           | Project        | ✅                 | ✅               | 🔒*                  |

--- a/dbtcloud/api.go
+++ b/dbtcloud/api.go
@@ -590,3 +590,61 @@ func (c *DbtCloudHTTPClient) GetAccountFeatures() []any {
 
 	return []any{features}
 }
+
+// GetProfiles fetches the profiles (project-scoped bindings of a connection,
+// credentials, and optional extended attributes) for each project in
+// listProjects, mirroring the per-project fetch pattern already used by
+// GetConnections/GetEnvironmentVariables above.
+//
+// The profiles endpoint itself doesn't return the warehouse type of the
+// credentials a profile points at, but callers (see the dbtcloud_profile
+// case in generate.go) need that to know which specific credential resource
+// type (dbtcloud_snowflake_credential, dbtcloud_bigquery_credential, etc.) a
+// profile's credentials_id should be linked to. We can't reuse
+// GetCredentials for this lookup because it only returns credentials that
+// are still attached to an environment's legacy credentials_id - which a
+// profile-bound environment's credentials never are, since those are bound
+// through the profile instead. So we fetch each project's credentials list
+// directly here and attach the matching credential (under the "credentials"
+// key) to each profile, mirroring how the environments endpoint already
+// embeds a nested "credentials" object for the same purpose.
+func (c *DbtCloudHTTPClient) GetProfiles(listProjects []int) []any {
+	projects := c.GetProjects(listProjects)
+	allProfiles := []any{}
+
+	for _, project := range projects {
+		projectTyped := project.(map[string]any)
+		projectID := int(projectTyped["id"].(float64))
+
+		if len(listProjects) > 0 && !lo.Contains(listProjects, projectID) {
+			continue
+		}
+
+		url := fmt.Sprintf("%s/v3/accounts/%s/projects/%d/profiles/", c.HostURL, c.AccountID, projectID)
+		projectProfiles := c.GetData(url)
+
+		if len(projectProfiles) == 0 {
+			continue
+		}
+
+		credentialsURL := fmt.Sprintf("%s/v3/accounts/%s/projects/%d/credentials/", c.HostURL, c.AccountID, projectID)
+		projectCredentials := c.GetData(credentialsURL)
+		credentialByID := map[float64]map[string]any{}
+		for _, credential := range projectCredentials {
+			credentialTyped := credential.(map[string]any)
+			credentialByID[credentialTyped["id"].(float64)] = credentialTyped
+		}
+
+		for _, profile := range projectProfiles {
+			profileTyped := profile.(map[string]any)
+			if credentialsID, ok := profileTyped["credentials_id"].(float64); ok {
+				if credentialDetails, found := credentialByID[credentialsID]; found {
+					profileTyped["credentials"] = credentialDetails
+				}
+			}
+			allProfiles = append(allProfiles, profileTyped)
+		}
+	}
+
+	return allProfiles
+}

--- a/dbtcloud/api.go
+++ b/dbtcloud/api.go
@@ -535,3 +535,58 @@ func (c *DbtCloudHTTPClient) GetGlobalConnections() []any {
 
 	return allConnectionDetails
 }
+
+// accountFeaturesData mirrors the payload returned by the account features
+// endpoint. The JSON keys on the wire use a mix of hyphens and underscores;
+// they get normalized to the underscored attribute names used by the
+// `dbtcloud_account_features` Terraform resource schema when GetAccountFeatures
+// builds its result map below.
+type accountFeaturesData struct {
+	AdvancedCI                 bool `json:"advanced-ci"`
+	PartialParsing             bool `json:"partial-parsing"`
+	RepoCaching                bool `json:"repo-caching"`
+	AIFeatures                 bool `json:"ai_features"`
+	CatalogIngestion           bool `json:"catalog-ingestion"`
+	ExplorerAccountUI          bool `json:"explorer-account-ui"`
+	FusionMigrationPermissions bool `json:"fusion-migration-permissions"`
+}
+
+type accountFeaturesResponse struct {
+	Data accountFeaturesData `json:"data"`
+}
+
+// GetAccountFeatures fetches the account-level feature flags (Advanced CI, AI
+// features, catalog ingestion, etc.) that gate whether certain dbt Cloud
+// resources (e.g. jobs using Advanced CI) can be created in an account.
+//
+// Unlike every other resource in this file, account features are a singleton:
+// there is exactly one set of flags per account rather than a list of items,
+// and the object has no numeric `id` of its own. We return a single-element
+// slice with `id` set to the account id so it fits the same []any shape the
+// rest of the generator/importer code already works with.
+func (c *DbtCloudHTTPClient) GetAccountFeatures() []any {
+	url := fmt.Sprintf("%s/private/accounts/%s/features/", c.HostURL, c.AccountID)
+
+	jsonPayload, err := c.GetEndpoint(url)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var response accountFeaturesResponse
+	if err := json.Unmarshal(jsonPayload, &response); err != nil {
+		log.Fatal(err)
+	}
+
+	features := map[string]any{
+		"id":                           c.AccountID,
+		"advanced_ci":                  response.Data.AdvancedCI,
+		"partial_parsing":              response.Data.PartialParsing,
+		"repo_caching":                 response.Data.RepoCaching,
+		"ai_features":                  response.Data.AIFeatures,
+		"catalog_ingestion":            response.Data.CatalogIngestion,
+		"explorer_account_ui":          response.Data.ExplorerAccountUI,
+		"fusion_migration_permissions": response.Data.FusionMigrationPermissions,
+	}
+
+	return []any{features}
+}

--- a/dbtcloud/api.go
+++ b/dbtcloud/api.go
@@ -536,6 +536,111 @@ func (c *DbtCloudHTTPClient) GetGlobalConnections() []any {
 	return allConnectionDetails
 }
 
+// EnvVarJobOverrideResponse mirrors the response envelope returned by the
+// job-scoped environment-variable override endpoint
+// (/v3/accounts/{account}/projects/{project}/environment-variables/job/?job_definition_id={job}).
+// Unlike the environment-scoped endpoint (see EnvVarResponse/EnvVarData
+// above), this endpoint's "data" is a flat map of env var name -> per-scope
+// override details (e.g. {"account": {...}, "environment": {...}, "job":
+// {...}}), with no intermediate "variables" wrapper.
+type EnvVarJobOverrideResponse struct {
+	Data map[string]any `json:"data"`
+}
+
+func (c *DbtCloudHTTPClient) GetDataEnvVarJobOverrides(url string) map[string]any {
+
+	jsonPayload, err := c.GetEndpoint(url)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var response EnvVarJobOverrideResponse
+
+	err = json.Unmarshal(jsonPayload, &response)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return response.Data
+}
+
+// GetEnvironmentVariableJobOverrides fetches per-job environment-variable
+// value overrides for the given jobs (typically the already-prefetched jobs
+// list generate.go/import.go build for other job-scoped resources), scoped
+// to listProjects.
+//
+// The override data doesn't live behind an account- or project-wide "list
+// all overrides" endpoint - it's only queryable per job_definition_id (see
+// GetEnvironmentVariableJobOverride in the provider's own client, which takes
+// a job_definition_id query param) - so we loop through the known jobs for
+// each project and query per job, mirroring the per-project-then-per-item
+// fetch pattern GetProfiles already uses above.
+//
+// Each returned item is a flattened map with "name" (the env var name),
+// "project_id", "job_definition_id", "environment_variable_job_override_id"
+// (the override's own numeric id - present so callers can fold a
+// project/job/override composite into a unique resource id, exactly as
+// GetProfiles's callers do for profile_id), and "raw_value" (the override's
+// value, matching the dbtcloud_environment_variable_job_override resource's
+// own attribute name).
+func (c *DbtCloudHTTPClient) GetEnvironmentVariableJobOverrides(listProjects []int, jobs []any) []any {
+	allOverrides := []any{}
+
+	jobIDsByProject := map[int][]int{}
+	for _, job := range jobs {
+		jobTyped := job.(map[string]any)
+		jobID := int(jobTyped["id"].(float64))
+		projectID := int(jobTyped["project_id"].(float64))
+		jobIDsByProject[projectID] = append(jobIDsByProject[projectID], jobID)
+	}
+
+	for projectID, jobIDs := range jobIDsByProject {
+		if len(listProjects) > 0 && !lo.Contains(listProjects, projectID) {
+			continue
+		}
+
+		for _, jobID := range jobIDs {
+			url := fmt.Sprintf("%s/v3/accounts/%s/projects/%d/environment-variables/job/?job_definition_id=%d", c.HostURL, c.AccountID, projectID, jobID)
+			jobOverrides := c.GetDataEnvVarJobOverrides(url)
+
+			for envVarName, value := range jobOverrides {
+				// "project" is a pseudo-key returned alongside the per-variable
+				// entries on the environment-scoped endpoint (see
+				// GetEnvironmentVariables); we haven't observed it here but skip
+				// it defensively for the same reason.
+				if envVarName == "project" {
+					continue
+				}
+
+				valueTyped, ok := value.(map[string]any)
+				if !ok {
+					continue
+				}
+
+				jobOverrideTyped, ok := valueTyped["job"].(map[string]any)
+				if !ok || jobOverrideTyped == nil {
+					// this env var has no job-level override for this job - only
+					// account/environment-level values, which aren't this
+					// resource's concern.
+					continue
+				}
+
+				overrideValue, _ := jobOverrideTyped["value"].(string)
+
+				allOverrides = append(allOverrides, map[string]any{
+					"name":                                 envVarName,
+					"project_id":                           float64(projectID),
+					"job_definition_id":                    float64(jobID),
+					"environment_variable_job_override_id": jobOverrideTyped["id"],
+					"raw_value":                            overrideValue,
+				})
+			}
+		}
+	}
+
+	return allOverrides
+}
+
 // accountFeaturesData mirrors the payload returned by the account features
 // endpoint. The JSON keys on the wire use a mix of hyphens and underscores;
 // they get normalized to the underscored attribute names used by the

--- a/internal/app/dbtcloud-terraforming/cmd/generate.go
+++ b/internal/app/dbtcloud-terraforming/cmd/generate.go
@@ -82,6 +82,141 @@ func computeResourceLabel(resourceType string, structData map[string]interface{}
 	return fmt.Sprintf("terraform_managed_resource_%s", id)
 }
 
+// transformEnvironmentForGenerate applies the dbtcloud_environment-specific
+// generate-time transforms to a single environment payload: optionally
+// linking project_id to a generated dbtcloud_project resource, and - the
+// core either/or invariant - binding the environment to either a profile
+// (via primary_profile_id) or the legacy connection_id/credential_id/
+// extended_attributes_id trio, but never both. The provider rejects setting
+// primary_profile_id alongside any of the legacy trio, so whichever
+// primary_profile_id is present on the payload decides which branch runs,
+// and the branch not taken is guaranteed absent from the result.
+//
+// It mutates and returns environmentsTyped in place, matching the mutate-in-
+// place style used by every other resource case in generateResources().
+func transformEnvironmentForGenerate(environmentsTyped map[string]any) map[string]any {
+	projectID := environmentsTyped["project_id"].(float64)
+
+	if linkResource("dbtcloud_project") {
+		environmentsTyped["project_id"] = fmt.Sprintf("%sdbtcloud_project.terraform_managed_resource_%0.f.id", prefixNoQuotes, projectID)
+	}
+
+	if primaryProfileID, hasProfile := environmentsTyped["primary_profile_id"].(float64); hasProfile {
+		if linkResource("dbtcloud_profile") {
+			environmentsTyped["primary_profile_id"] = fmt.Sprintf("%sdbtcloud_profile.terraform_managed_resource_%0.f_%0.f.profile_id", prefixNoQuotes, projectID, primaryProfileID)
+		}
+
+		// omit the legacy trio entirely - both the raw API field names and the
+		// "credential_id" rename performed in the non-profile branch below.
+		delete(environmentsTyped, "connection_id")
+		delete(environmentsTyped, "credentials_id")
+		delete(environmentsTyped, "credential_id")
+		delete(environmentsTyped, "extended_attributes_id")
+	} else {
+		// handle the case when credentialID is not a float because it is null
+		if credentialID, ok := environmentsTyped["credentials_id"].(float64); ok {
+
+			environmentsTyped["credential_id"] = credentialID
+			if linkResource("dbtcloud_snowflake_credential") || linkResource("dbtcloud_bigquery_credential") || linkResource("dbtcloud_databricks_credential") {
+
+				credentials, credentialsOK := environmentsTyped["credentials"].(map[string]any)
+
+				if credentialsOK {
+					credentialsType := credentials["type"].(string)
+					adapterVersion := credentials["adapter_version"].(string)
+
+					if lo.Contains([]string{"snowflake", "bigquery"}, credentialsType) {
+						environmentsTyped["credential_id"] = fmt.Sprintf("%sdbtcloud_%s_credential.terraform_managed_resource_%0.f.credential_id", prefixNoQuotes, credentialsType, credentialID)
+					} else if adapterVersion == "databricks_v0" {
+						environmentsTyped["credential_id"] = fmt.Sprintf("%sdbtcloud_databricks_credential.terraform_managed_resource_%0.f.credential_id", prefixNoQuotes, credentialID)
+					} else {
+						environmentsTyped["credential_id"] = fmt.Sprintf("---TBD---credential type not supported yet for %s---", adapterVersion)
+					}
+
+				} else {
+					environmentsTyped["credential_id"] = "---TBD---"
+				}
+			}
+		}
+		if linkResource("dbtcloud_global_connection") {
+			connectionID := environmentsTyped["connection_id"].(float64)
+			environmentsTyped["connection_id"] = fmt.Sprintf("%sdbtcloud_global_connection.terraform_managed_resource_%0.f.id", prefixNoQuotes, connectionID)
+		}
+
+		// handle the case when extended_attributes_id is not set
+		if extendedAttributesID, ok := environmentsTyped["extended_attributes_id"].(float64); ok {
+			if linkResource("dbtcloud_extended_attributes") {
+				environmentsTyped["extended_attributes_id"] = fmt.Sprintf("%sdbtcloud_extended_attributes.terraform_managed_resource_%0.f.extended_attributes_id", prefixNoQuotes, extendedAttributesID)
+			}
+		}
+	}
+
+	return environmentsTyped
+}
+
+// transformProfileForGenerate applies the dbtcloud_profile-specific
+// generate-time transforms to a single profile payload: it folds project_id
+// into the "id" field (see the resourceIDOverride discussion on the
+// dbtcloud_profile case above for why - profile_id is only unique within a
+// project, not across the account), keeps the plain numeric profile id
+// separately as "profile_id" for the resource's own attribute, and
+// optionally links project_id/connection_id/credentials_id/
+// extended_attributes_id to their generated counterparts, mirroring
+// transformEnvironmentForGenerate's linking logic exactly.
+//
+// It mutates and returns profileTyped in place, matching the mutate-in-place
+// style used by every other resource case in generateResources().
+func transformProfileForGenerate(profileTyped map[string]any) map[string]any {
+	projectID := profileTyped["project_id"].(float64)
+	profileID := profileTyped["id"].(float64)
+
+	profileTyped["profile_id"] = profileID
+	profileTyped["id"] = fmt.Sprintf("%.0f_%.0f", projectID, profileID)
+
+	if linkResource("dbtcloud_project") {
+		profileTyped["project_id"] = fmt.Sprintf("%sdbtcloud_project.terraform_managed_resource_%0.f.id", prefixNoQuotes, projectID)
+	}
+
+	if connectionID, ok := profileTyped["connection_id"].(float64); ok {
+		if linkResource("dbtcloud_global_connection") {
+			profileTyped["connection_id"] = fmt.Sprintf("%sdbtcloud_global_connection.terraform_managed_resource_%0.f.id", prefixNoQuotes, connectionID)
+		}
+	}
+
+	// handle the case when credentialsID is not a float because it is null
+	if credentialsID, ok := profileTyped["credentials_id"].(float64); ok {
+		if linkResource("dbtcloud_snowflake_credential") || linkResource("dbtcloud_bigquery_credential") || linkResource("dbtcloud_databricks_credential") {
+
+			credentials, credentialsOK := profileTyped["credentials"].(map[string]any)
+
+			if credentialsOK {
+				credentialsType := credentials["type"].(string)
+				adapterVersion := credentials["adapter_version"].(string)
+
+				if lo.Contains([]string{"snowflake", "bigquery"}, credentialsType) {
+					profileTyped["credentials_id"] = fmt.Sprintf("%sdbtcloud_%s_credential.terraform_managed_resource_%0.f.credential_id", prefixNoQuotes, credentialsType, credentialsID)
+				} else if adapterVersion == "databricks_v0" {
+					profileTyped["credentials_id"] = fmt.Sprintf("%sdbtcloud_databricks_credential.terraform_managed_resource_%0.f.credential_id", prefixNoQuotes, credentialsID)
+				} else {
+					profileTyped["credentials_id"] = fmt.Sprintf("---TBD---credential type not supported yet for %s---", adapterVersion)
+				}
+
+			} else {
+				profileTyped["credentials_id"] = "---TBD---"
+			}
+		}
+	}
+
+	// handle the case when extended_attributes_id is not set
+	if extendedAttributesID, ok := profileTyped["extended_attributes_id"].(float64); ok {
+		if linkResource("dbtcloud_extended_attributes") {
+			profileTyped["extended_attributes_id"] = fmt.Sprintf("%sdbtcloud_extended_attributes.terraform_managed_resource_%0.f.extended_attributes_id", prefixNoQuotes, extendedAttributesID)
+		}
+	}
+
+	return profileTyped
+}
+
 func generateResources() func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
 		if outputFile != "" {
@@ -331,50 +466,7 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 
 				for _, environment := range listEnvironments {
 					environmentsTyped := environment.(map[string]any)
-					projectID := environmentsTyped["project_id"].(float64)
-
-					if linkResource("dbtcloud_project") {
-						environmentsTyped["project_id"] = fmt.Sprintf("%sdbtcloud_project.terraform_managed_resource_%0.f.id", prefixNoQuotes, projectID)
-					}
-
-					// handle the case when credentialID is not a float because it is null
-					if credentialID, ok := environmentsTyped["credentials_id"].(float64); ok {
-
-						environmentsTyped["credential_id"] = credentialID
-						if linkResource("dbtcloud_snowflake_credential") || linkResource("dbtcloud_bigquery_credential") || linkResource("dbtcloud_databricks_credential") {
-
-							credentials, credentialsOK := environmentsTyped["credentials"].(map[string]any)
-
-							if credentialsOK {
-								credentialsType := credentials["type"].(string)
-								adapterVersion := credentials["adapter_version"].(string)
-
-								if lo.Contains([]string{"snowflake", "bigquery"}, credentialsType) {
-									environmentsTyped["credential_id"] = fmt.Sprintf("%sdbtcloud_%s_credential.terraform_managed_resource_%0.f.credential_id", prefixNoQuotes, credentialsType, credentialID)
-								} else if adapterVersion == "databricks_v0" {
-									environmentsTyped["credential_id"] = fmt.Sprintf("%sdbtcloud_databricks_credential.terraform_managed_resource_%0.f.credential_id", prefixNoQuotes, credentialID)
-								} else {
-									environmentsTyped["credential_id"] = fmt.Sprintf("---TBD---credential type not supported yet for %s---", adapterVersion)
-								}
-
-							} else {
-								environmentsTyped["credential_id"] = "---TBD---"
-							}
-						}
-					}
-					if linkResource("dbtcloud_global_connection") {
-						connectionID := environmentsTyped["connection_id"].(float64)
-						environmentsTyped["connection_id"] = fmt.Sprintf("%sdbtcloud_global_connection.terraform_managed_resource_%0.f.id", prefixNoQuotes, connectionID)
-					}
-
-					// handle the case when extended_attributes_id is not set
-					if extendedAttributesID, ok := environmentsTyped["extended_attributes_id"].(float64); ok {
-						if linkResource("dbtcloud_extended_attributes") {
-							environmentsTyped["extended_attributes_id"] = fmt.Sprintf("%sdbtcloud_extended_attributes.terraform_managed_resource_%0.f.extended_attributes_id", prefixNoQuotes, extendedAttributesID)
-						}
-					}
-
-					jsonStructData = append(jsonStructData, environmentsTyped)
+					jsonStructData = append(jsonStructData, transformEnvironmentForGenerate(environmentsTyped))
 				}
 
 				resourceCount = len(jsonStructData)
@@ -1038,6 +1130,29 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 				jsonStructData = dbtCloudClient.GetAccountFeatures()
 				resourceCount = len(jsonStructData)
 				resourceIDOverride = "account_features"
+
+			// dbtcloud_profile is project-scoped and its `profile_id` is only
+			// unique within a project, not across the account, so a plain
+			// numeric label (as used by e.g. dbtcloud_environment) could collide
+			// across projects. Rather than generalizing resourceIDOverride to
+			// vary per item (it is a single value shared by every item of a
+			// resource type in the post-switch loop below), we fold project_id
+			// into structData["id"] itself - exactly the approach
+			// dbtcloud_environment_variable already uses for its own composite
+			// id above. computeResourceLabel's existing string-id path then
+			// picks this up unchanged, and the plain numeric profile id is kept
+			// separately as "profile_id" for the resource's own attribute and
+			// for the import composite address.
+			case "dbtcloud_profile":
+
+				listProfiles := dbtCloudClient.GetProfiles(listFilterProjects)
+
+				for _, profile := range listProfiles {
+					profileTyped := profile.(map[string]any)
+					jsonStructData = append(jsonStructData, transformProfileForGenerate(profileTyped))
+				}
+
+				resourceCount = len(jsonStructData)
 
 			default:
 				fmt.Fprintf(cmd.OutOrStderr(), "%q is not yet supported for automatic generation", resourceType)

--- a/internal/app/dbtcloud-terraforming/cmd/generate.go
+++ b/internal/app/dbtcloud-terraforming/cmd/generate.go
@@ -54,6 +54,34 @@ func linkResource(resourceType string) bool {
 	return lo.Contains(listLinkedResources, resourceType) || listLinkedResources[0] == "all"
 }
 
+// computeResourceLabel derives the `terraform_managed_resource_<suffix>` label
+// used for a generated `resource "..." "..."` block.
+//
+// If resourceIDOverride is non-empty, it is used directly as the suffix - this
+// is how a resource's `case` above opts a resource out of id-based labelling,
+// which is needed for resources that aren't keyed by a single numeric/string
+// id (e.g. dbtcloud_account_features, a singleton with no per-item id).
+//
+// Otherwise the suffix is derived from structData["id"], exactly as it always
+// has been for every other (list-based, id-keyed) resource type.
+func computeResourceLabel(resourceType string, structData map[string]interface{}, resourceIDOverride string) string {
+	if resourceIDOverride != "" {
+		return fmt.Sprintf("terraform_managed_resource_%s", resourceIDOverride)
+	}
+
+	id := ""
+	switch structData["id"].(type) {
+	case float64:
+		id = fmt.Sprintf("%.0f", structData["id"].(float64))
+	case nil:
+		panic(fmt.Sprintf("There is no `id` defined for the resource %s", resourceType))
+	default:
+		id = structData["id"].(string)
+	}
+
+	return fmt.Sprintf("terraform_managed_resource_%s", id)
+}
+
 func generateResources() func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
 		if outputFile != "" {
@@ -178,6 +206,14 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 			// to allow it to be referenced further down in the loop that outputs the
 			// newly generated resources.
 			resourceCount := 0
+
+			// resourceIDOverride lets a `case` below set the resource label used in
+			// the generated `resource "..." "..."` block directly, instead of it being
+			// derived from `structData["id"]`. This is needed for resources that
+			// aren't keyed by a single numeric/string id - e.g. singletons like
+			// dbtcloud_account_features, which have exactly one instance per account
+			// and no `id` field of their own.
+			resourceIDOverride := ""
 
 			var jsonStructData []any
 
@@ -994,6 +1030,15 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 
 				resourceCount = len(jsonStructData)
 
+			// account_features is a singleton: one set of feature flags per account,
+			// not a list of items, so there's no per-item `id` to derive a resource
+			// label from. We label it directly via resourceIDOverride instead.
+			case "dbtcloud_account_features":
+
+				jsonStructData = dbtCloudClient.GetAccountFeatures()
+				resourceCount = len(jsonStructData)
+				resourceIDOverride = "account_features"
+
 			default:
 				fmt.Fprintf(cmd.OutOrStderr(), "%q is not yet supported for automatic generation", resourceType)
 				return
@@ -1012,17 +1057,7 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 				if os.Getenv("USE_STATIC_RESOURCE_IDS") == "true" {
 					resourceID = "terraform_managed_resource"
 				} else {
-					id := ""
-					switch structData["id"].(type) {
-					case float64:
-						id = fmt.Sprintf("%.0f", structData["id"].(float64))
-					case nil:
-						panic(fmt.Sprintf("There is no `id` defined for the resource %s", resourceType))
-					default:
-						id = structData["id"].(string)
-					}
-
-					resourceID = fmt.Sprintf("terraform_managed_resource_%s", id)
+					resourceID = computeResourceLabel(resourceType, structData, resourceIDOverride)
 				}
 				resource := rootBody.AppendNewBlock("resource", []string{resourceType, resourceID}).Body()
 

--- a/internal/app/dbtcloud-terraforming/cmd/generate.go
+++ b/internal/app/dbtcloud-terraforming/cmd/generate.go
@@ -217,6 +217,105 @@ func transformProfileForGenerate(profileTyped map[string]any) map[string]any {
 	return profileTyped
 }
 
+// transformJobCompletionTriggerForGenerate builds the jsonStructData entry
+// for a single dbtcloud_job_completion_trigger, from the
+// job_completion_trigger_condition field already present on a dbtcloud_job
+// payload (see the dbtcloud_job case in generateResources(), which parses
+// this same field for its own, separate purposes).
+//
+// It returns (nil, false) when the job carries no completion trigger
+// condition at all, so callers can skip it without generating an empty
+// resource.
+//
+// The real dbtcloud_job_completion_trigger resource schema is flat - job_id
+// (the downstream job this trigger is attached to), trigger_job_id (the
+// upstream job whose completion fires it), project_id, and statuses - with
+// no nested "condition" block, confirmed against the provider's schema
+// source. Its id is just the downstream job's plain numeric id (matching the
+// provider's ImportState, which parses the import id directly as job_id),
+// so no composite-id folding is needed here, unlike
+// transformProfileForGenerate.
+func transformJobCompletionTriggerForGenerate(jobTyped map[string]any) (map[string]any, bool) {
+	jobCompletionTrigger, ok := jobTyped["job_completion_trigger_condition"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	condition, ok := jobCompletionTrigger["condition"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+
+	downstreamJobID := jobTyped["id"].(float64)
+	upstreamProjectID := condition["project_id"].(float64)
+	upstreamJobID := condition["job_id"].(float64)
+
+	triggerData := map[string]any{
+		"id":             downstreamJobID,
+		"job_id":         downstreamJobID,
+		"trigger_job_id": upstreamJobID,
+		"project_id":     upstreamProjectID,
+		"statuses":       mapJobStatusCodeToText(condition["statuses"].([]any)),
+	}
+
+	if linkResource("dbtcloud_job") {
+		triggerData["job_id"] = fmt.Sprintf("%sdbtcloud_job.terraform_managed_resource_%0.f.id", prefixNoQuotes, downstreamJobID)
+		triggerData["trigger_job_id"] = fmt.Sprintf("%sdbtcloud_job.terraform_managed_resource_%0.f.id", prefixNoQuotes, upstreamJobID)
+	}
+	if linkResource("dbtcloud_project") {
+		triggerData["project_id"] = fmt.Sprintf("%sdbtcloud_project.terraform_managed_resource_%0.f.id", prefixNoQuotes, upstreamProjectID)
+	}
+
+	return triggerData, true
+}
+
+// transformEnvironmentVariableJobOverrideForGenerate applies the
+// dbtcloud_environment_variable_job_override-specific generate-time
+// transforms to a single override payload (as returned by
+// GetEnvironmentVariableJobOverrides): it folds project_id/job_definition_id/
+// the override's own numeric id into "id" (mirroring transformProfileForGenerate's
+// approach, since environment_variable_job_override_id is only meaningful
+// together with the project/job scope it lives in), externalizes the value
+// of a secret-named override (DBT_ENV_SECRET_ prefix) to a Terraform
+// variable exactly as the existing dbtcloud_environment_variable case does,
+// and optionally links job_definition_id/project_id to their generated
+// counterparts.
+//
+// It mutates and returns overrideTyped in place, matching the mutate-in-place
+// style used by every other resource transform in this file.
+func transformEnvironmentVariableJobOverrideForGenerate(overrideTyped map[string]any) map[string]any {
+	projectID := overrideTyped["project_id"].(float64)
+	jobDefinitionID := overrideTyped["job_definition_id"].(float64)
+	overrideID := overrideTyped["environment_variable_job_override_id"].(float64)
+	envVarName := overrideTyped["name"].(string)
+
+	overrideTyped["id"] = fmt.Sprintf("%.0f_%.0f_%.0f", projectID, jobDefinitionID, overrideID)
+
+	// mirror the DBT_ENV_SECRET_ externalization pattern used by the
+	// existing dbtcloud_environment_variable case exactly: a secret-named
+	// override's value is registered as a Terraform variable and
+	// substituted with a var.<name> reference instead of being emitted
+	// inline.
+	if strings.HasPrefix(envVarName, "DBT_ENV_SECRET_") {
+		targetURL := fmt.Sprintf("%s/deploy/%s/projects/%.0f/jobs/%.0f/settings/", dbtCloudClient.HostURL[:len(dbtCloudClient.HostURL)-4], dbtCloudClient.AccountID, projectID, jobDefinitionID)
+		varName := fmt.Sprintf("dbtcloud_environment_variable_job_override_%.0f_%.0f_%s", projectID, jobDefinitionID, slug.Make(envVarName))
+		AllTFVars = append(AllTFVars, tfVar{
+			varType:        "string",
+			varName:        varName,
+			varDescription: "The secret env var override for " + envVarName + " on job " + fmt.Sprintf("%.0f", jobDefinitionID) + " in the project " + fmt.Sprintf("%.0f", projectID) + " - " + targetURL,
+		})
+		overrideTyped["raw_value"] = fmt.Sprintf("%svar.%s", prefixNoQuotes, varName)
+	}
+
+	if linkResource("dbtcloud_job") {
+		overrideTyped["job_definition_id"] = fmt.Sprintf("%sdbtcloud_job.terraform_managed_resource_%0.f.id", prefixNoQuotes, jobDefinitionID)
+	}
+	if linkResource("dbtcloud_project") {
+		overrideTyped["project_id"] = fmt.Sprintf("%sdbtcloud_project.terraform_managed_resource_%0.f.id", prefixNoQuotes, projectID)
+	}
+
+	return overrideTyped
+}
+
 func generateResources() func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
 		if outputFile != "" {
@@ -305,13 +404,28 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 
 		// we only get jobs if we need them, there might be a lot of them
 		prefetchedJobs := []any{}
-		resourceNeedingJobs := []string{"dbtcloud_job", "dbtcloud_webhook", "dbtcloud_notification"}
+		resourceNeedingJobs := []string{"dbtcloud_job", "dbtcloud_webhook", "dbtcloud_notification", "dbtcloud_job_completion_trigger", "dbtcloud_environment_variable_job_override"}
 		if len(lo.Intersect(resourceTypes, resourceNeedingJobs)) > 0 {
 			prefetchedJobs = dbtCloudClient.GetJobs(listFilterProjects)
 		}
 		prefetchedJobsIDs := lo.Map(prefetchedJobs, func(job any, index int) int {
 			return int(job.(map[string]any)["id"].(float64))
 		})
+
+		// the dbtcloud_job case below mutates each job's own
+		// job_completion_trigger_condition field in place for its own
+		// purposes (jobs and prefetchedJobs share the same underlying map
+		// objects). We extract the completion-trigger data for
+		// dbtcloud_job_completion_trigger here, before that mutation can
+		// happen, so its output doesn't depend on whether/when "dbtcloud_job"
+		// is processed in the same invocation.
+		prefetchedJobCompletionTriggers := []any{}
+		for _, job := range prefetchedJobs {
+			jobTyped := job.(map[string]any)
+			if triggerData, ok := transformJobCompletionTriggerForGenerate(jobTyped); ok {
+				prefetchedJobCompletionTriggers = append(prefetchedJobCompletionTriggers, triggerData)
+			}
+		}
 		// we need this because our API for webhooks returns job IDs as strings
 		prefetchedJobsIDsString := lo.Map(prefetchedJobsIDs, func(jobID int, index int) string {
 			return fmt.Sprintf("%d", jobID)
@@ -1150,6 +1264,43 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 				for _, profile := range listProfiles {
 					profileTyped := profile.(map[string]any)
 					jsonStructData = append(jsonStructData, transformProfileForGenerate(profileTyped))
+				}
+
+				resourceCount = len(jsonStructData)
+
+			// dbtcloud_job_completion_trigger reproduces, as its own
+			// standalone resource, the "run after" relationship that already
+			// rides along on a job's own payload under
+			// job_completion_trigger_condition (see the dbtcloud_job case
+			// above, which already parses this same field for its own
+			// purposes). Per the real provider schema, the standalone
+			// resource's attributes are flat - job_id (the downstream job
+			// this trigger is attached to), trigger_job_id (the upstream job
+			// whose completion fires it), project_id, and statuses - with no
+			// nested "condition" block. Its id is just the downstream job's
+			// plain numeric id (matching the provider's ImportState, which
+			// parses the import id directly as job_id), so no composite-id
+			// folding is needed here, unlike dbtcloud_profile.
+			case "dbtcloud_job_completion_trigger":
+
+				jsonStructData = prefetchedJobCompletionTriggers
+				resourceCount = len(jsonStructData)
+
+			// dbtcloud_environment_variable_job_override's true id
+			// (environment_variable_job_override_id) is only meaningful
+			// together with the project/job scope it lives in, so - exactly
+			// as dbtcloud_profile and dbtcloud_environment_variable already
+			// do above - we fold project_id/job_definition_id/override_id
+			// into structData["id"] for the resource label, while keeping
+			// the plain numeric override id under
+			// "environment_variable_job_override_id" for the import address.
+			case "dbtcloud_environment_variable_job_override":
+
+				listOverrides := dbtCloudClient.GetEnvironmentVariableJobOverrides(listFilterProjects, prefetchedJobs)
+
+				for _, override := range listOverrides {
+					overrideTyped := override.(map[string]any)
+					jsonStructData = append(jsonStructData, transformEnvironmentVariableJobOverrideForGenerate(overrideTyped))
 				}
 
 				resourceCount = len(jsonStructData)

--- a/internal/app/dbtcloud-terraforming/cmd/generate_test.go
+++ b/internal/app/dbtcloud-terraforming/cmd/generate_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"testing"
 
@@ -93,6 +94,15 @@ func TestResourceGeneration(t *testing.T) {
 		"dbt Cloud projects":     {identifierType: "account", resourceType: "dbtcloud_project", testdataFilename: "dbtcloud_project"},
 		"dbt Cloud jobs":         {identifierType: "account", resourceType: "dbtcloud_job", testdataFilename: "dbtcloud_job"},
 		"dbt Cloud repositories": {identifierType: "account", resourceType: "dbtcloud_repository", testdataFilename: "dbtcloud_repository"},
+		// NOTE: the "dbtcloud_account_features" cassette (testdata/dbtcloud/dbtcloud_account_features.yaml)
+		// has not been recorded yet - recording it requires live account credentials via:
+		//   OVERWRITE_VCR_CASSETTES=true go test ./internal/app/dbtcloud-terraforming/cmd/... \
+		//     -run TestResourceGeneration/dbt_Cloud_account_features -v
+		// Until that cassette exists, this row is scaffolded but will fail if run; see
+		// TestGenerate_ComputeResourceLabel and TestGenerate_AccountFeaturesHCLEmission for
+		// standalone unit coverage of the singleton ID handling and attribute emission in
+		// the meantime.
+		"dbt Cloud account features": {identifierType: "account", resourceType: "dbtcloud_account_features", testdataFilename: "dbtcloud_account_features"},
 	}
 
 	for name, tc := range tests {
@@ -165,4 +175,132 @@ func TestResourceGeneration(t *testing.T) {
 			assert.Equal(t, strings.TrimRight(expected, "\n"), strings.TrimRight(output, "\n"))
 		})
 	}
+}
+
+// TestGenerate_ComputeResourceLabel covers the generalized ID-derivation logic
+// used to label generated `resource "..." "..."` blocks: the existing
+// numeric/string id-based behavior for list-based resources must stay
+// byte-identical, while a non-empty resourceIDOverride must let a resource
+// (e.g. the dbtcloud_account_features singleton) opt out of id-based
+// labelling entirely.
+func TestGenerate_ComputeResourceLabel(t *testing.T) {
+	tests := map[string]struct {
+		resourceType       string
+		structData         map[string]interface{}
+		resourceIDOverride string
+		want               string
+	}{
+		"numeric id, no override (existing behavior, e.g. dbtcloud_project)": {
+			resourceType: "dbtcloud_project",
+			structData:   map[string]interface{}{"id": float64(123)},
+			want:         "terraform_managed_resource_123",
+		},
+		"string id, no override (existing behavior, e.g. dbtcloud_environment_variable)": {
+			resourceType: "dbtcloud_environment_variable",
+			structData:   map[string]interface{}{"id": "71_DBT_ENV"},
+			want:         "terraform_managed_resource_71_DBT_ENV",
+		},
+		"singleton override takes precedence over structData id": {
+			resourceType:       "dbtcloud_account_features",
+			structData:         map[string]interface{}{"id": "1234"},
+			resourceIDOverride: "account_features",
+			want:               "terraform_managed_resource_account_features",
+		},
+		"singleton override with no id in structData at all": {
+			resourceType:       "dbtcloud_account_features",
+			structData:         map[string]interface{}{},
+			resourceIDOverride: "account_features",
+			want:               "terraform_managed_resource_account_features",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := computeResourceLabel(tc.resourceType, tc.structData, tc.resourceIDOverride)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestGenerate_ComputeResourceLabelPanicsOnMissingID locks in the existing
+// panic behavior for resources with no id and no override - this is the
+// pre-existing guard against silently generating an unlabelled resource
+// block, and must keep working for every currently-supported id-keyed
+// resource type.
+func TestGenerate_ComputeResourceLabelPanicsOnMissingID(t *testing.T) {
+	assert.Panics(t, func() {
+		computeResourceLabel("dbtcloud_project", map[string]interface{}{}, "")
+	})
+}
+
+// fabricatedAccountFeaturesPayload mimics the single-element shape returned
+// by dbtCloudClient.GetAccountFeatures(): a singleton object keyed by the
+// account id rather than a per-item numeric id, with boolean feature flags
+// matching the dbtcloud_account_features Terraform resource's attribute
+// names.
+func fabricatedAccountFeaturesPayload() map[string]interface{} {
+	return map[string]interface{}{
+		"id":                           "1234",
+		"advanced_ci":                  true,
+		"partial_parsing":              false,
+		"repo_caching":                 true,
+		"ai_features":                  true,
+		"catalog_ingestion":            false,
+		"explorer_account_ui":          true,
+		"fusion_migration_permissions": false,
+	}
+}
+
+// TestGenerate_AccountFeaturesHCLEmission feeds a fabricated account features
+// payload through the same label-derivation and attribute-emission
+// primitives (computeResourceLabel, writeAttrLine) that generate.go's
+// schema-driven loop uses for every resource, and asserts that the resulting
+// HCL carries the singleton resource label and the expected boolean
+// attributes. This does not require a live account or the Terraform provider
+// schema (see the scaffolded, not-yet-recorded "dbt Cloud account features"
+// row in TestResourceGeneration for full end-to-end coverage once a cassette
+// exists).
+func TestGenerate_AccountFeaturesHCLEmission(t *testing.T) {
+	features := fabricatedAccountFeaturesPayload()
+
+	resourceLabel := computeResourceLabel("dbtcloud_account_features", features, "account_features")
+	assert.Equal(t, "terraform_managed_resource_account_features", resourceLabel)
+
+	f := hclwrite.NewEmptyFile()
+	resource := f.Body().AppendNewBlock("resource", []string{"dbtcloud_account_features", resourceLabel}).Body()
+
+	attrNames := make([]string, 0, len(features))
+	for k := range features {
+		if k == "id" {
+			// id is never emitted as an attribute - it's only used for
+			// import/state purposes, matching every other resource type.
+			continue
+		}
+		attrNames = append(attrNames, k)
+	}
+	sort.Strings(attrNames)
+
+	for _, attrName := range attrNames {
+		writeAttrLine(attrName, features[attrName], "", resource)
+	}
+
+	output := string(f.Bytes())
+
+	assert.Contains(t, output, `resource "dbtcloud_account_features" "terraform_managed_resource_account_features"`)
+	// hclwrite aligns "=" signs to the longest attribute name in the block, so
+	// match on the key/value pair rather than an exact single-space rendering.
+	for _, want := range []string{
+		"advanced_ci",
+		"partial_parsing",
+		"repo_caching",
+		"ai_features",
+		"catalog_ingestion",
+		"explorer_account_ui",
+		"fusion_migration_permissions",
+	} {
+		re := regexp.MustCompile(fmt.Sprintf(`(?m)^\s*%s\s*= (true|false)$`, regexp.QuoteMeta(want)))
+		assert.Regexp(t, re, output, "expected attribute %q to be emitted", want)
+	}
+	assert.True(t, strings.Contains(output, "true") && strings.Contains(output, "false"), "expected both true and false flag values to be emitted")
+	assert.NotRegexp(t, regexp.MustCompile(`(?m)^\s*id\s*=`), output, "the id field must not be emitted as an attribute")
 }

--- a/internal/app/dbtcloud-terraforming/cmd/generate_test.go
+++ b/internal/app/dbtcloud-terraforming/cmd/generate_test.go
@@ -112,6 +112,28 @@ func TestResourceGeneration(t *testing.T) {
 		// standalone unit coverage of the composite ID handling and attribute emission in
 		// the meantime.
 		"dbt Cloud profiles": {identifierType: "account", resourceType: "dbtcloud_profile", testdataFilename: "dbtcloud_profile"},
+		// NOTE: the "dbtcloud_job_completion_trigger" cassette (testdata/dbtcloud/dbtcloud_job_completion_trigger_resource.yaml)
+		// has not been recorded yet - recording it requires a live account with at
+		// least one job with a completion trigger configured, via:
+		//   OVERWRITE_VCR_CASSETTES=true go test ./internal/app/dbtcloud-terraforming/cmd/... \
+		//     -run TestResourceGeneration/dbt_Cloud_job_completion_triggers -v
+		// Until that cassette exists, this row is scaffolded but will fail if run; see
+		// TestGenerate_TransformJobCompletionTriggerForGenerate and
+		// TestGenerate_JobCompletionTriggerHCLEmission for standalone unit coverage of the
+		// trigger extraction, status mapping, and attribute emission in the meantime.
+		"dbt Cloud job completion triggers": {identifierType: "account", resourceType: "dbtcloud_job_completion_trigger", testdataFilename: "dbtcloud_job_completion_trigger_resource"},
+		// NOTE: the "dbtcloud_environment_variable_job_override" cassette
+		// (testdata/dbtcloud/dbtcloud_environment_variable_job_override.yaml) has not been
+		// recorded yet - recording it requires a live account with at least one job-level
+		// environment variable override configured, via:
+		//   OVERWRITE_VCR_CASSETTES=true go test ./internal/app/dbtcloud-terraforming/cmd/... \
+		//     -run TestResourceGeneration/dbt_Cloud_environment_variable_job_overrides -v
+		// Until that cassette exists, this row is scaffolded but will fail if run; see
+		// TestGenerate_TransformEnvironmentVariableJobOverrideForGenerate and
+		// TestGenerate_EnvironmentVariableJobOverrideHCLEmission for standalone unit coverage
+		// of the composite ID handling, secret externalization, and attribute emission in the
+		// meantime.
+		"dbt Cloud environment variable job overrides": {identifierType: "account", resourceType: "dbtcloud_environment_variable_job_override", testdataFilename: "dbtcloud_environment_variable_job_override"},
 	}
 
 	for name, tc := range tests {
@@ -479,5 +501,236 @@ func TestGenerate_TransformEnvironmentForGenerate_EitherOr(t *testing.T) {
 		assert.Equal(t, float64(20), got["connection_id"])
 		assert.Equal(t, float64(30), got["credential_id"], "credentials_id is renamed to credential_id, matching pre-existing behavior")
 		assert.Equal(t, float64(40), got["extended_attributes_id"])
+	})
+}
+
+// fabricatedJobWithCompletionTriggerPayload mimics a single element of the
+// []any returned by dbtCloudClient.GetJobs(): a job whose
+// job_completion_trigger_condition field (already parsed by the existing
+// dbtcloud_job case, for its own separate purposes) carries the "run after"
+// relationship dbtcloud_job_completion_trigger reproduces as a standalone
+// resource. withCondition controls whether the condition is present at all,
+// matching jobs that have no completion trigger configured.
+func fabricatedJobWithCompletionTriggerPayload(withCondition bool) map[string]any {
+	job := map[string]any{
+		"id":         float64(456),
+		"project_id": float64(71),
+	}
+	if withCondition {
+		job["job_completion_trigger_condition"] = map[string]any{
+			"condition": map[string]any{
+				"job_id":     float64(123),
+				"project_id": float64(99),
+				"statuses":   []any{float64(10), float64(20)},
+			},
+		}
+	}
+	return job
+}
+
+// TestGenerate_TransformJobCompletionTriggerForGenerate covers the
+// dbtcloud_job_completion_trigger extraction from a job's own payload: a job
+// with no completion trigger condition must be skipped entirely (ok=false),
+// the numeric status codes on the condition must be mapped to their text
+// equivalents via mapJobStatusCodeToText rather than left as raw codes, and
+// job_id/trigger_job_id must only become linked references when the
+// corresponding resource type is in --linked-resource-types.
+func TestGenerate_TransformJobCompletionTriggerForGenerate(t *testing.T) {
+	t.Run("job with no completion trigger condition is skipped", func(t *testing.T) {
+		job := fabricatedJobWithCompletionTriggerPayload(false)
+		_, ok := transformJobCompletionTriggerForGenerate(job)
+		assert.False(t, ok)
+	})
+
+	t.Run("no linking: statuses are mapped to text, ids stay numeric", func(t *testing.T) {
+		job := fabricatedJobWithCompletionTriggerPayload(true)
+		got, ok := transformJobCompletionTriggerForGenerate(job)
+		assert.True(t, ok)
+
+		assert.Equal(t, float64(456), got["id"], "id is the downstream job's own plain numeric id")
+		assert.Equal(t, float64(456), got["job_id"])
+		assert.Equal(t, float64(123), got["trigger_job_id"])
+		assert.Equal(t, float64(99), got["project_id"])
+		assert.Equal(t, []string{"success", "error"}, got["statuses"], "numeric status codes must be mapped to text, not left raw")
+	})
+
+	t.Run("linking dbtcloud_job and dbtcloud_project rewrites references", func(t *testing.T) {
+		withLinkedResources(t, []string{"dbtcloud_job", "dbtcloud_project"})
+
+		job := fabricatedJobWithCompletionTriggerPayload(true)
+		got, ok := transformJobCompletionTriggerForGenerate(job)
+		assert.True(t, ok)
+
+		assert.Contains(t, got["job_id"], "dbtcloud_job.terraform_managed_resource_456.id", "job_id links to the downstream job")
+		assert.Contains(t, got["trigger_job_id"], "dbtcloud_job.terraform_managed_resource_123.id", "trigger_job_id links to the upstream job")
+		assert.Contains(t, got["project_id"], "dbtcloud_project.terraform_managed_resource_99.id")
+	})
+}
+
+// TestGenerate_JobCompletionTriggerHCLEmission feeds a fabricated
+// job-with-trigger payload through the same label-derivation and
+// attribute-emission primitives (computeResourceLabel, writeAttrLine) that
+// generate.go's schema-driven loop uses for every resource, and asserts that
+// the resulting HCL carries the flat job_id/trigger_job_id/project_id/
+// statuses attributes (mapped to text status strings, not numeric codes)
+// confirmed against the real provider schema - and that job_id/
+// trigger_job_id are linked when linking is on.
+func TestGenerate_JobCompletionTriggerHCLEmission(t *testing.T) {
+	withLinkedResources(t, []string{"dbtcloud_job"})
+
+	job := fabricatedJobWithCompletionTriggerPayload(true)
+	trigger, ok := transformJobCompletionTriggerForGenerate(job)
+	assert.True(t, ok)
+
+	resourceLabel := computeResourceLabel("dbtcloud_job_completion_trigger", trigger, "")
+	assert.Equal(t, "terraform_managed_resource_456", resourceLabel)
+
+	f := hclwrite.NewEmptyFile()
+	resource := f.Body().AppendNewBlock("resource", []string{"dbtcloud_job_completion_trigger", resourceLabel}).Body()
+
+	for _, attrName := range []string{"job_id", "trigger_job_id", "project_id", "statuses"} {
+		writeAttrLine(attrName, trigger[attrName], "", resource)
+	}
+
+	output := string(f.Bytes())
+
+	assert.Contains(t, output, `resource "dbtcloud_job_completion_trigger" "terraform_managed_resource_456"`)
+	assert.Contains(t, output, "dbtcloud_job.terraform_managed_resource_456.id", "job_id must be linked to the downstream job")
+	assert.Contains(t, output, "dbtcloud_job.terraform_managed_resource_123.id", "trigger_job_id must be linked to the upstream job")
+	assert.Contains(t, output, `"success"`)
+	assert.Contains(t, output, `"error"`)
+	assert.NotContains(t, output, "10", "the raw numeric status code must not leak into the output")
+	assert.NotRegexp(t, regexp.MustCompile(`(?m)^\s*condition\s*\{`), output, "the real provider schema has no nested condition block")
+}
+
+// fabricatedEnvVarJobOverridePayload mimics a single element of the []any
+// returned by dbtCloudClient.GetEnvironmentVariableJobOverrides(): a
+// job-scoped environment variable override. name controls whether the
+// override matches the DBT_ENV_SECRET_ convention that must externalize its
+// value to a Terraform variable.
+func fabricatedEnvVarJobOverridePayload(name string) map[string]any {
+	return map[string]any{
+		"name":                                 name,
+		"project_id":                           float64(71),
+		"job_definition_id":                    float64(456),
+		"environment_variable_job_override_id": float64(789),
+		"raw_value":                            "my-value",
+	}
+}
+
+// TestGenerate_TransformEnvironmentVariableJobOverrideForGenerate covers the
+// dbtcloud_environment_variable_job_override generate-time transform: the
+// composite id folding (project_id/job_definition_id/override_id into "id")
+// must happen regardless of linking or secrecy, a non-secret-named
+// override's raw_value must stay literal, a DBT_ENV_SECRET_-named override's
+// raw_value must be externalized to a var.* reference and registered in
+// AllTFVars, and job_definition_id/project_id must only become linked
+// references when the corresponding resource type is in
+// --linked-resource-types.
+func TestGenerate_TransformEnvironmentVariableJobOverrideForGenerate(t *testing.T) {
+	origTFVars := AllTFVars
+	origClient := dbtCloudClient
+	// the secret-externalization branch builds a "manage this in the UI"
+	// target URL off dbtCloudClient.HostURL/AccountID, exactly like the
+	// existing dbtcloud_environment_variable case does - so, like that code,
+	// it needs a non-nil client even outside of a full generate run.
+	dbtCloudClient = dbtcloud.NewDbtCloudHTTPClient("https://cloud.getdbt.com/api", "token", "9999", nil)
+	t.Cleanup(func() {
+		AllTFVars = origTFVars
+		dbtCloudClient = origClient
+	})
+
+	t.Run("no linking, non-secret name: id is folded, raw_value stays literal", func(t *testing.T) {
+		AllTFVars = []tfVar{}
+		override := fabricatedEnvVarJobOverridePayload("MY_PLAIN_VAR")
+		got := transformEnvironmentVariableJobOverrideForGenerate(override)
+
+		assert.Equal(t, "71_456_789", got["id"])
+		assert.Equal(t, float64(71), got["project_id"])
+		assert.Equal(t, float64(456), got["job_definition_id"])
+		assert.Equal(t, "my-value", got["raw_value"], "a non-secret-named override keeps its literal value inline")
+		assert.Empty(t, AllTFVars, "no Terraform variable should be registered for a non-secret override")
+	})
+
+	t.Run("secret name: raw_value is externalized to a var.* reference", func(t *testing.T) {
+		AllTFVars = []tfVar{}
+		override := fabricatedEnvVarJobOverridePayload("DBT_ENV_SECRET_TOKEN")
+		got := transformEnvironmentVariableJobOverrideForGenerate(override)
+
+		assert.Equal(t, "71_456_789", got["id"], "the composite id must still be folded for a secret-named override")
+		assert.Contains(t, got["raw_value"], "var.", "a secret-named override's value must be externalized")
+		assert.NotContains(t, got["raw_value"], "my-value", "the literal secret value must not leak into the output")
+		assert.Len(t, AllTFVars, 1, "exactly one Terraform variable must be registered for the secret override")
+		assert.Contains(t, got["raw_value"], AllTFVars[0].varName)
+	})
+
+	t.Run("linking dbtcloud_job and dbtcloud_project rewrites references", func(t *testing.T) {
+		AllTFVars = []tfVar{}
+		withLinkedResources(t, []string{"dbtcloud_job", "dbtcloud_project"})
+
+		override := fabricatedEnvVarJobOverridePayload("MY_PLAIN_VAR")
+		got := transformEnvironmentVariableJobOverrideForGenerate(override)
+
+		assert.Equal(t, "71_456_789", got["id"], "the composite id must still be derived from the original numeric ids")
+		assert.Contains(t, got["job_definition_id"], "dbtcloud_job.terraform_managed_resource_456.id")
+		assert.Contains(t, got["project_id"], "dbtcloud_project.terraform_managed_resource_71.id")
+	})
+}
+
+// TestGenerate_EnvironmentVariableJobOverrideHCLEmission feeds fabricated
+// override payloads through the same label-derivation and attribute-emission
+// primitives (computeResourceLabel, writeAttrLine) that generate.go's
+// schema-driven loop uses for every resource, and asserts the resulting HCL
+// carries the project-scoped composite label, a linked job_definition_id,
+// and - critically - that a secret-named override's raw_value is a var.*
+// reference in the output while a non-secret-named override's raw_value
+// stays a literal string.
+func TestGenerate_EnvironmentVariableJobOverrideHCLEmission(t *testing.T) {
+	origTFVars := AllTFVars
+	origClient := dbtCloudClient
+	dbtCloudClient = dbtcloud.NewDbtCloudHTTPClient("https://cloud.getdbt.com/api", "token", "9999", nil)
+	t.Cleanup(func() {
+		AllTFVars = origTFVars
+		dbtCloudClient = origClient
+	})
+
+	t.Run("non-secret override emits the literal value", func(t *testing.T) {
+		AllTFVars = []tfVar{}
+		withLinkedResources(t, []string{"dbtcloud_job"})
+
+		override := transformEnvironmentVariableJobOverrideForGenerate(fabricatedEnvVarJobOverridePayload("MY_PLAIN_VAR"))
+
+		resourceLabel := computeResourceLabel("dbtcloud_environment_variable_job_override", override, "")
+		assert.Equal(t, "terraform_managed_resource_71_456_789", resourceLabel)
+
+		f := hclwrite.NewEmptyFile()
+		resource := f.Body().AppendNewBlock("resource", []string{"dbtcloud_environment_variable_job_override", resourceLabel}).Body()
+		for _, attrName := range []string{"name", "project_id", "job_definition_id", "raw_value"} {
+			writeAttrLine(attrName, override[attrName], "", resource)
+		}
+
+		output := string(f.Bytes())
+		assert.Contains(t, output, `resource "dbtcloud_environment_variable_job_override" "terraform_managed_resource_71_456_789"`)
+		assert.Contains(t, output, "dbtcloud_job.terraform_managed_resource_456.id")
+		assert.Contains(t, output, `"my-value"`, "a non-secret-named override's value must be emitted literally")
+	})
+
+	t.Run("secret override emits a var.* reference instead of the literal value", func(t *testing.T) {
+		AllTFVars = []tfVar{}
+		withLinkedResources(t, []string{"dbtcloud_job"})
+
+		override := transformEnvironmentVariableJobOverrideForGenerate(fabricatedEnvVarJobOverridePayload("DBT_ENV_SECRET_TOKEN"))
+
+		resourceLabel := computeResourceLabel("dbtcloud_environment_variable_job_override", override, "")
+
+		f := hclwrite.NewEmptyFile()
+		resource := f.Body().AppendNewBlock("resource", []string{"dbtcloud_environment_variable_job_override", resourceLabel}).Body()
+		for _, attrName := range []string{"name", "project_id", "job_definition_id", "raw_value"} {
+			writeAttrLine(attrName, override[attrName], "", resource)
+		}
+
+		output := string(f.Bytes())
+		assert.Contains(t, output, "var.", "a secret-named override's value must be a var.* reference in the output")
+		assert.NotContains(t, output, `"my-value"`, "the literal secret value must never be emitted")
 	})
 }

--- a/internal/app/dbtcloud-terraforming/cmd/generate_test.go
+++ b/internal/app/dbtcloud-terraforming/cmd/generate_test.go
@@ -103,6 +103,15 @@ func TestResourceGeneration(t *testing.T) {
 		// standalone unit coverage of the singleton ID handling and attribute emission in
 		// the meantime.
 		"dbt Cloud account features": {identifierType: "account", resourceType: "dbtcloud_account_features", testdataFilename: "dbtcloud_account_features"},
+		// NOTE: the "dbtcloud_profile" cassette (testdata/dbtcloud/dbtcloud_profile.yaml)
+		// has not been recorded yet - recording it requires live account credentials via:
+		//   OVERWRITE_VCR_CASSETTES=true go test ./internal/app/dbtcloud-terraforming/cmd/... \
+		//     -run TestResourceGeneration/dbt_Cloud_profiles -v
+		// Until that cassette exists, this row is scaffolded but will fail if run; see
+		// TestGenerate_ProfileHCLEmission and TestGenerate_TransformProfileForGenerate for
+		// standalone unit coverage of the composite ID handling and attribute emission in
+		// the meantime.
+		"dbt Cloud profiles": {identifierType: "account", resourceType: "dbtcloud_profile", testdataFilename: "dbtcloud_profile"},
 	}
 
 	for name, tc := range tests {
@@ -303,4 +312,172 @@ func TestGenerate_AccountFeaturesHCLEmission(t *testing.T) {
 	}
 	assert.True(t, strings.Contains(output, "true") && strings.Contains(output, "false"), "expected both true and false flag values to be emitted")
 	assert.NotRegexp(t, regexp.MustCompile(`(?m)^\s*id\s*=`), output, "the id field must not be emitted as an attribute")
+}
+
+// withLinkedResources temporarily sets the package-level listLinkedResources
+// used by linkResource() for the duration of a test, restoring the previous
+// value afterwards. Tests that don't call this leave linking off, matching
+// linkResource's own "no resources configured -> false" default.
+func withLinkedResources(t *testing.T, linked []string) {
+	t.Helper()
+	orig := listLinkedResources
+	listLinkedResources = linked
+	t.Cleanup(func() { listLinkedResources = orig })
+}
+
+// fabricatedProfilePayload mimics a single element of the []any returned by
+// dbtCloudClient.GetProfiles(): a project-scoped profile with the attribute
+// names confirmed against the terraform-provider-dbtcloud schema (key,
+// connection_id, credentials_id - plural, extended_attributes_id optional).
+func fabricatedProfilePayload() map[string]any {
+	return map[string]any{
+		"id":             float64(10),
+		"project_id":     float64(5),
+		"key":            "my-profile",
+		"connection_id":  float64(20),
+		"credentials_id": float64(30),
+	}
+}
+
+// TestGenerate_TransformProfileForGenerate covers the dbtcloud_profile
+// generate-time transform: the composite id folding (project_id into "id",
+// plain id preserved as "profile_id") must happen regardless of linking, and
+// linked references must only replace connection_id/credentials_id/
+// project_id when the corresponding resource type is in
+// --linked-resource-types.
+func TestGenerate_TransformProfileForGenerate(t *testing.T) {
+	t.Run("no linking: ids stay numeric except the folded composite id", func(t *testing.T) {
+		profile := fabricatedProfilePayload()
+		got := transformProfileForGenerate(profile)
+
+		assert.Equal(t, "5_10", got["id"])
+		assert.Equal(t, float64(10), got["profile_id"])
+		assert.Equal(t, float64(5), got["project_id"])
+		assert.Equal(t, float64(20), got["connection_id"])
+		assert.Equal(t, float64(30), got["credentials_id"])
+	})
+
+	t.Run("linking dbtcloud_project and dbtcloud_global_connection rewrites references", func(t *testing.T) {
+		withLinkedResources(t, []string{"dbtcloud_project", "dbtcloud_global_connection"})
+
+		profile := fabricatedProfilePayload()
+		got := transformProfileForGenerate(profile)
+
+		assert.Equal(t, "5_10", got["id"], "the composite id must still be derived from the original numeric project_id")
+		assert.Contains(t, got["project_id"], "dbtcloud_project.terraform_managed_resource_5.id")
+		assert.Contains(t, got["connection_id"], "dbtcloud_global_connection.terraform_managed_resource_20.id")
+	})
+
+	t.Run("linking dbtcloud_snowflake_credential without embedded credentials type falls back to TBD", func(t *testing.T) {
+		withLinkedResources(t, []string{"dbtcloud_snowflake_credential"})
+
+		profile := fabricatedProfilePayload()
+		got := transformProfileForGenerate(profile)
+
+		assert.Equal(t, "---TBD---", got["credentials_id"])
+	})
+
+	t.Run("linking dbtcloud_snowflake_credential with embedded credentials type resolves the reference", func(t *testing.T) {
+		withLinkedResources(t, []string{"dbtcloud_snowflake_credential"})
+
+		profile := fabricatedProfilePayload()
+		profile["credentials"] = map[string]any{"type": "snowflake", "adapter_version": ""}
+		got := transformProfileForGenerate(profile)
+
+		assert.Contains(t, got["credentials_id"], "dbtcloud_snowflake_credential.terraform_managed_resource_30.credential_id")
+	})
+}
+
+// TestGenerate_ProfileHCLEmission feeds a fabricated profile payload through
+// the same label-derivation and attribute-emission primitives
+// (computeResourceLabel, writeAttrLine) that generate.go's schema-driven
+// loop uses for every resource, asserting the resulting HCL carries the
+// project-scoped composite label and the confirmed attribute names.
+func TestGenerate_ProfileHCLEmission(t *testing.T) {
+	profile := transformProfileForGenerate(fabricatedProfilePayload())
+
+	resourceLabel := computeResourceLabel("dbtcloud_profile", profile, "")
+	assert.Equal(t, "terraform_managed_resource_5_10", resourceLabel)
+
+	f := hclwrite.NewEmptyFile()
+	resource := f.Body().AppendNewBlock("resource", []string{"dbtcloud_profile", resourceLabel}).Body()
+
+	// profile_id is a computed-only attribute in the real provider schema
+	// (like credential_id on the credential resources), so it - like id -
+	// would never reach writeAttrLine via generate.go's schema-driven loop.
+	for _, attrName := range []string{"project_id", "key", "connection_id", "credentials_id"} {
+		writeAttrLine(attrName, profile[attrName], "", resource)
+	}
+
+	output := string(f.Bytes())
+
+	assert.Contains(t, output, `resource "dbtcloud_profile" "terraform_managed_resource_5_10"`)
+	assert.Contains(t, output, `key`)
+	assert.Contains(t, output, "connection_id")
+	assert.Contains(t, output, "credentials_id")
+	assert.NotRegexp(t, regexp.MustCompile(`(?m)^\s*id\s*=`), output, "the id field must not be emitted as an attribute")
+	assert.NotRegexp(t, regexp.MustCompile(`(?m)^\s*profile_id\s*=`), output, "profile_id is computed-only and must not be emitted as an attribute")
+}
+
+// fabricatedEnvironmentPayload mimics a single element of the []any returned
+// by dbtCloudClient.GetEnvironments(): withProfile controls whether the
+// environment carries a primary_profile_id (profile-based account) or the
+// legacy connection_id/credentials_id/extended_attributes_id trio
+// (non-profile account) - never both, matching what the real API returns.
+func fabricatedEnvironmentPayload(withProfile bool) map[string]any {
+	env := map[string]any{
+		"id":         float64(456),
+		"project_id": float64(71),
+		"name":       "prod",
+	}
+	if withProfile {
+		env["primary_profile_id"] = float64(10)
+	} else {
+		env["connection_id"] = float64(20)
+		env["credentials_id"] = float64(30)
+		env["extended_attributes_id"] = float64(40)
+	}
+	return env
+}
+
+// TestGenerate_TransformEnvironmentForGenerate_EitherOr is the core
+// regression test for the never-both invariant: a profile-bound environment
+// must emit primary_profile_id and none of the legacy trio, a non-profile
+// environment must be completely unchanged from the pre-existing behavior,
+// and neither branch may ever leave both primary_profile_id and any of the
+// legacy trio present at once.
+func TestGenerate_TransformEnvironmentForGenerate_EitherOr(t *testing.T) {
+	t.Run("profile-bound environment: primary_profile_id present, legacy trio absent", func(t *testing.T) {
+		env := fabricatedEnvironmentPayload(true)
+		got := transformEnvironmentForGenerate(env)
+
+		assert.Contains(t, got, "primary_profile_id")
+		assert.Equal(t, float64(10), got["primary_profile_id"], "without linking, primary_profile_id stays the plain numeric profile id")
+
+		for _, legacyField := range []string{"connection_id", "credential_id", "credentials_id", "extended_attributes_id"} {
+			assert.NotContains(t, got, legacyField, "legacy field %q must be absent whenever primary_profile_id is present", legacyField)
+		}
+	})
+
+	t.Run("profile-bound environment with linking: primary_profile_id resolves to the profile resource, legacy trio still absent", func(t *testing.T) {
+		withLinkedResources(t, []string{"dbtcloud_profile"})
+
+		env := fabricatedEnvironmentPayload(true)
+		got := transformEnvironmentForGenerate(env)
+
+		assert.Contains(t, got["primary_profile_id"], "dbtcloud_profile.terraform_managed_resource_71_10.profile_id")
+		for _, legacyField := range []string{"connection_id", "credential_id", "credentials_id", "extended_attributes_id"} {
+			assert.NotContains(t, got, legacyField)
+		}
+	})
+
+	t.Run("non-profile environment: legacy trio unchanged, primary_profile_id absent", func(t *testing.T) {
+		env := fabricatedEnvironmentPayload(false)
+		got := transformEnvironmentForGenerate(env)
+
+		assert.NotContains(t, got, "primary_profile_id")
+		assert.Equal(t, float64(20), got["connection_id"])
+		assert.Equal(t, float64(30), got["credential_id"], "credentials_id is renamed to credential_id, matching pre-existing behavior")
+		assert.Equal(t, float64(40), got["extended_attributes_id"])
+	})
 }

--- a/internal/app/dbtcloud-terraforming/cmd/import.go
+++ b/internal/app/dbtcloud-terraforming/cmd/import.go
@@ -37,6 +37,13 @@ var resourceImportStringFormats = map[string]string{
 	// account_features is a singleton: there's exactly one instance per account,
 	// keyed by the account id rather than a per-item id.
 	"dbtcloud_account_features": ":id",
+	// dbtcloud_profile's composite id is project_id:profile_id. Unlike
+	// dbtcloud_environment's ":project_id::id" (whose ":id" resolves against
+	// the plain resource id passed into buildRawImportAddress), the profile's
+	// resource id is itself a composite label (project_id folded in, see the
+	// dbtcloud_profile case in generate.go and GetProfiles in api.go), so we
+	// resolve against the separate numeric "profile_id" field instead.
+	"dbtcloud_profile": ":project_id::profile_id",
 }
 
 func init() {
@@ -201,6 +208,29 @@ func runImport() func(cmd *cobra.Command, args []string) {
 			case "dbtcloud_account_features":
 				jsonStructData = dbtCloudClient.GetAccountFeatures()
 
+			case "dbtcloud_profile":
+				listProfiles := dbtCloudClient.GetProfiles(listFilterProjects)
+
+				listImportProfiles := []any{}
+				for _, profile := range listProfiles {
+					profileTyped := profile.(map[string]any)
+					projectID := profileTyped["project_id"].(float64)
+					profileID := profileTyped["id"].(float64)
+
+					// profile_id is only unique within a project, not across the
+					// account, so - exactly as generate.go's dbtcloud_profile case
+					// does - we fold project_id into "id" to get a resource address
+					// that matches the label `generate` produces for the same
+					// profile, and keep the plain numeric id separately as
+					// "profile_id" for the :profile_id placeholder used by the
+					// composite import address template above.
+					profileTyped["profile_id"] = profileID
+					profileTyped["id"] = fmt.Sprintf("%.0f_%.0f", projectID, profileID)
+
+					listImportProfiles = append(listImportProfiles, profileTyped)
+				}
+				jsonStructData = listImportProfiles
+
 			default:
 				fmt.Fprintf(cmd.OutOrStderr(), "%q is not yet supported for state import", resourceType)
 				return
@@ -296,6 +326,7 @@ func buildRawImportAddress(resourceType, resourceID string, data any) string {
 	connectionID := resolveImportField(dataTyped, "connection_id", "no-connection_id")
 	repositoryID := resolveImportField(dataTyped, "repository_id", "no-repository_id")
 	projectID := resolveImportField(dataTyped, "project_id", "no-project_id")
+	profileID := resolveImportField(dataTyped, "profile_id", "no-profile_id")
 	name := resolveImportField(dataTyped, "name", "no-name")
 
 	var userID string
@@ -316,6 +347,7 @@ func buildRawImportAddress(resourceType, resourceID string, data any) string {
 		":connection_id", connectionID,
 		":repository_id", repositoryID,
 		":project_id", projectID,
+		":profile_id", profileID,
 		":name", name,
 		":user_id", userID,
 	)

--- a/internal/app/dbtcloud-terraforming/cmd/import.go
+++ b/internal/app/dbtcloud-terraforming/cmd/import.go
@@ -34,6 +34,9 @@ var resourceImportStringFormats = map[string]string{
 	"dbtcloud_notification":          ":id",
 	"dbtcloud_service_token":         ":id",
 	"dbtcloud_global_connection":     ":id",
+	// account_features is a singleton: there's exactly one instance per account,
+	// keyed by the account id rather than a per-item id.
+	"dbtcloud_account_features": ":id",
 }
 
 func init() {
@@ -195,6 +198,9 @@ func runImport() func(cmd *cobra.Command, args []string) {
 			case "dbtcloud_global_connection":
 				jsonStructData = dbtCloudClient.GetGlobalConnectionsSummary()
 
+			case "dbtcloud_account_features":
+				jsonStructData = dbtCloudClient.GetAccountFeatures()
+
 			default:
 				fmt.Fprintf(cmd.OutOrStderr(), "%q is not yet supported for state import", resourceType)
 				return
@@ -241,6 +247,39 @@ func buildTerraformImportCommand(resourceType, resourceID string, data interface
 	return fmt.Sprintf("%s %s.%s_%s %s\n", terraformImportCmdPrefix, resourceType, terraformResourceNamePrefix, resourceID, resourceImportAddress)
 }
 
+// resolveImportField looks up key in data and formats it the way import string
+// templates expect: numeric ids without a decimal point, strings as-is. If the
+// key is missing, nil, or of an unexpected type, fallback is returned instead -
+// this keeps a broken/missing field visible in the generated import address
+// rather than silently producing an incomplete one.
+//
+// This is the shared resolver behind every non-`:id` composite placeholder
+// (e.g. `:project_id`, `:connection_id`, `:repository_id`, `:name`) used by
+// resourceImportStringFormats, so a template can resolve any field present on
+// the resource's data - whether that's a single numeric id, part of a
+// composite key such as `:project_id::id`, or (via the `:id` placeholder
+// itself, substituted separately in buildRawImportAddress) a singleton keyed
+// by the account id.
+func resolveImportField(data map[string]any, key, fallback string) string {
+	if data == nil {
+		return fallback
+	}
+
+	raw, ok := data[key]
+	if !ok || raw == nil {
+		return fallback
+	}
+
+	switch v := raw.(type) {
+	case float64:
+		return fmt.Sprintf("%0.f", v)
+	case string:
+		return v
+	default:
+		return fallback
+	}
+}
+
 // buildRawImportAddress takes the resourceType and resourceID in order to lookup the
 // resource type import string and then return a suitable composite value that
 // is compatible with `terraform import`.
@@ -249,59 +288,22 @@ func buildRawImportAddress(resourceType, resourceID string, data any) string {
 		log.Fatalf("%s does not have an import format defined", resourceType)
 	}
 
-	var identifierType string
-	var identifierValue string
+	identifierType := "account"
+	identifierValue := accountID
 
-	identifierType = "account"
-	identifierValue = accountID
+	dataTyped, _ := data.(map[string]any)
 
-	connectionIDRaw, ok := data.(map[string]any)["connection_id"]
-	var connectionID string
-	if !ok {
-		connectionID = "no-connection_id"
-	} else {
-		connectionIDFloat, ok := connectionIDRaw.(float64)
-		if !ok {
-			connectionID = "no-connection_id"
-		} else {
-			connectionID = fmt.Sprintf("%0.f", connectionIDFloat)
-		}
-	}
-
-	repositoryIDCasted, ok := data.(map[string]any)["repository_id"].(float64)
-	var repositoryID string
-	if !ok {
-		repositoryID = "no-repository_id"
-	} else {
-		repositoryID = fmt.Sprintf("%0.f", repositoryIDCasted)
-	}
-
-	projectIDRaw, ok := data.(map[string]any)["project_id"]
-	var projectID string
-	if !ok {
-		projectID = "no-project_id"
-	} else {
-		projectID = fmt.Sprintf("%0.f", projectIDRaw.(float64))
-	}
-
-	nameRaw, ok := data.(map[string]any)["name"]
-	var name string
-	if !ok {
-		name = "no-name"
-	} else {
-		name = nameRaw.(string)
-	}
+	connectionID := resolveImportField(dataTyped, "connection_id", "no-connection_id")
+	repositoryID := resolveImportField(dataTyped, "repository_id", "no-repository_id")
+	projectID := resolveImportField(dataTyped, "project_id", "no-project_id")
+	name := resolveImportField(dataTyped, "name", "no-name")
 
 	var userID string
 	if resourceType == "dbtcloud_user_groups" {
-		// for dbtcloud_user_groups, the ID is the user ID
-		userIDRaw, ok := data.(map[string]any)["id"]
-		_ = userIDRaw
-		if !ok {
-			userID = "no-userid"
-		} else {
-			userID = fmt.Sprintf("%0.f", userIDRaw.(float64))
-		}
+		// for dbtcloud_user_groups, the composite id template's :user_id
+		// placeholder resolves against the top-level `id` field (the user id),
+		// not a `user_id` field.
+		userID = resolveImportField(dataTyped, "id", "no-userid")
 	}
 
 	s := resourceImportStringFormats[resourceType]

--- a/internal/app/dbtcloud-terraforming/cmd/import.go
+++ b/internal/app/dbtcloud-terraforming/cmd/import.go
@@ -44,6 +44,20 @@ var resourceImportStringFormats = map[string]string{
 	// dbtcloud_profile case in generate.go and GetProfiles in api.go), so we
 	// resolve against the separate numeric "profile_id" field instead.
 	"dbtcloud_profile": ":project_id::profile_id",
+	// dbtcloud_job_completion_trigger's own id is just the plain numeric id
+	// of the downstream job it's attached to (matching the provider's
+	// ImportState, which parses the import id directly as job_id) - no
+	// composite folding needed, unlike dbtcloud_profile.
+	"dbtcloud_job_completion_trigger": ":id",
+	// dbtcloud_environment_variable_job_override's real import id is
+	// project_id:job_definition_id:environment_variable_job_override_id (per
+	// the provider's ImportState). Its resource id is folded (project_id,
+	// job_definition_id, and the override id all baked into "id", see the
+	// dbtcloud_environment_variable_job_override case in generate.go), so -
+	// exactly like dbtcloud_profile's ":profile_id" - we resolve the last
+	// segment against the separate numeric
+	// "environment_variable_job_override_id" field instead of ":id".
+	"dbtcloud_environment_variable_job_override": ":project_id::job_definition_id::environment_variable_job_override_id",
 }
 
 func init() {
@@ -92,7 +106,7 @@ func runImport() func(cmd *cobra.Command, args []string) {
 		importBody := importFile.Body()
 
 		prefetchedJobs := []any{}
-		resourceNeedingJobs := []string{"dbtcloud_job", "dbtcloud_webhook"}
+		resourceNeedingJobs := []string{"dbtcloud_job", "dbtcloud_webhook", "dbtcloud_job_completion_trigger", "dbtcloud_environment_variable_job_override"}
 		if len(lo.Intersect(resourceTypes, resourceNeedingJobs)) > 0 {
 			prefetchedJobs = dbtCloudClient.GetJobs(listFilterProjects)
 		}
@@ -231,6 +245,45 @@ func runImport() func(cmd *cobra.Command, args []string) {
 				}
 				jsonStructData = listImportProfiles
 
+			case "dbtcloud_job_completion_trigger":
+				listImportTriggers := []any{}
+				for _, job := range prefetchedJobs {
+					jobTyped := job.(map[string]any)
+					if _, ok := jobTyped["job_completion_trigger_condition"].(map[string]any); !ok {
+						continue
+					}
+					// the resource's own id is just the downstream job's
+					// plain numeric id - see the format entry above.
+					listImportTriggers = append(listImportTriggers, map[string]any{
+						"id": jobTyped["id"],
+					})
+				}
+				jsonStructData = listImportTriggers
+
+			case "dbtcloud_environment_variable_job_override":
+				listOverrides := dbtCloudClient.GetEnvironmentVariableJobOverrides(listFilterProjects, prefetchedJobs)
+
+				listImportOverrides := []any{}
+				for _, override := range listOverrides {
+					overrideTyped := override.(map[string]any)
+
+					projectID := overrideTyped["project_id"].(float64)
+					jobDefinitionID := overrideTyped["job_definition_id"].(float64)
+					overrideID := overrideTyped["environment_variable_job_override_id"].(float64)
+
+					// fold project_id/job_definition_id/override_id into "id"
+					// to get a resource address matching the label generate.go
+					// produces for the same override - exactly as
+					// dbtcloud_profile's import case does above - while
+					// keeping the plain numeric override id available for the
+					// ":environment_variable_job_override_id" placeholder used
+					// by the composite import address template above.
+					overrideTyped["id"] = fmt.Sprintf("%.0f_%.0f_%.0f", projectID, jobDefinitionID, overrideID)
+
+					listImportOverrides = append(listImportOverrides, overrideTyped)
+				}
+				jsonStructData = listImportOverrides
+
 			default:
 				fmt.Fprintf(cmd.OutOrStderr(), "%q is not yet supported for state import", resourceType)
 				return
@@ -328,6 +381,8 @@ func buildRawImportAddress(resourceType, resourceID string, data any) string {
 	projectID := resolveImportField(dataTyped, "project_id", "no-project_id")
 	profileID := resolveImportField(dataTyped, "profile_id", "no-profile_id")
 	name := resolveImportField(dataTyped, "name", "no-name")
+	jobDefinitionID := resolveImportField(dataTyped, "job_definition_id", "no-job_definition_id")
+	environmentVariableJobOverrideID := resolveImportField(dataTyped, "environment_variable_job_override_id", "no-environment_variable_job_override_id")
 
 	var userID string
 	if resourceType == "dbtcloud_user_groups" {
@@ -350,6 +405,8 @@ func buildRawImportAddress(resourceType, resourceID string, data any) string {
 		":profile_id", profileID,
 		":name", name,
 		":user_id", userID,
+		":job_definition_id", jobDefinitionID,
+		":environment_variable_job_override_id", environmentVariableJobOverrideID,
 	)
 
 	return replacer.Replace(s)

--- a/internal/app/dbtcloud-terraforming/cmd/import_test.go
+++ b/internal/app/dbtcloud-terraforming/cmd/import_test.go
@@ -16,6 +16,81 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestImport_BuildRawImportAddress locks the generalized import-string
+// builder (resourceImportStringFormats + buildRawImportAddress /
+// resolveImportField) against regressions. It covers:
+//   - (a) an existing numeric-id resource's format is unchanged
+//     (dbtcloud_project, ":id").
+//   - (b) a composite-id template resolves correctly
+//     (dbtcloud_environment, ":project_id::id").
+//   - (c) the new singleton format resolves correctly
+//     (dbtcloud_account_features, ":id" resolved against the account id).
+func TestImport_BuildRawImportAddress(t *testing.T) {
+	origAccountID := accountID
+	defer func() { accountID = origAccountID }()
+	accountID = "9999"
+
+	tests := map[string]struct {
+		resourceType string
+		resourceID   string
+		data         map[string]any
+		want         string
+	}{
+		"existing numeric-id resource (dbtcloud_project) is unchanged": {
+			resourceType: "dbtcloud_project",
+			resourceID:   "123",
+			data:         map[string]any{"id": float64(123)},
+			want:         "123",
+		},
+		"existing composite-id resource (dbtcloud_environment) resolves :project_id::id": {
+			resourceType: "dbtcloud_environment",
+			resourceID:   "456",
+			data:         map[string]any{"id": float64(456), "project_id": float64(71)},
+			want:         "71:456",
+		},
+		"new singleton resource (dbtcloud_account_features) resolves :id to the account id": {
+			resourceType: "dbtcloud_account_features",
+			resourceID:   "9999",
+			data:         map[string]any{"id": "9999"},
+			want:         "9999",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := buildRawImportAddress(tc.resourceType, tc.resourceID, tc.data)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestImport_ResolveImportField covers the shared field resolver extracted
+// from buildRawImportAddress, including the fallback strings that must stay
+// byte-identical to what the previous per-field hardcoded logic produced.
+func TestImport_ResolveImportField(t *testing.T) {
+	tests := map[string]struct {
+		data     map[string]any
+		key      string
+		fallback string
+		want     string
+	}{
+		"numeric field present":     {data: map[string]any{"project_id": float64(71)}, key: "project_id", fallback: "no-project_id", want: "71"},
+		"string field present":      {data: map[string]any{"name": "my-resource"}, key: "name", fallback: "no-name", want: "my-resource"},
+		"field absent":              {data: map[string]any{}, key: "connection_id", fallback: "no-connection_id", want: "no-connection_id"},
+		"field nil":                 {data: map[string]any{"connection_id": nil}, key: "connection_id", fallback: "no-connection_id", want: "no-connection_id"},
+		"field unexpected type":     {data: map[string]any{"repository_id": true}, key: "repository_id", fallback: "no-repository_id", want: "no-repository_id"},
+		"nil data map":              {data: nil, key: "name", fallback: "no-name", want: "no-name"},
+		"user_groups id-as-user_id": {data: map[string]any{"id": float64(42)}, key: "id", fallback: "no-userid", want: "42"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := resolveImportField(tc.data, tc.key, tc.fallback)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestResourceImport(t *testing.T) {
 
 	changeExpectedJobs := []string{

--- a/internal/app/dbtcloud-terraforming/cmd/import_test.go
+++ b/internal/app/dbtcloud-terraforming/cmd/import_test.go
@@ -54,6 +54,12 @@ func TestImport_BuildRawImportAddress(t *testing.T) {
 			data:         map[string]any{"id": "9999"},
 			want:         "9999",
 		},
+		"new project-scoped composite resource (dbtcloud_profile) resolves :project_id::profile_id": {
+			resourceType: "dbtcloud_profile",
+			resourceID:   "5_10",
+			data:         map[string]any{"id": "5_10", "project_id": float64(5), "profile_id": float64(10)},
+			want:         "5:10",
+		},
 	}
 
 	for name, tc := range tests {
@@ -81,6 +87,7 @@ func TestImport_ResolveImportField(t *testing.T) {
 		"field unexpected type":     {data: map[string]any{"repository_id": true}, key: "repository_id", fallback: "no-repository_id", want: "no-repository_id"},
 		"nil data map":              {data: nil, key: "name", fallback: "no-name", want: "no-name"},
 		"user_groups id-as-user_id": {data: map[string]any{"id": float64(42)}, key: "id", fallback: "no-userid", want: "42"},
+		"profile_id field present":  {data: map[string]any{"profile_id": float64(10)}, key: "profile_id", fallback: "no-profile_id", want: "10"},
 	}
 
 	for name, tc := range tests {

--- a/internal/app/dbtcloud-terraforming/cmd/import_test.go
+++ b/internal/app/dbtcloud-terraforming/cmd/import_test.go
@@ -60,6 +60,23 @@ func TestImport_BuildRawImportAddress(t *testing.T) {
 			data:         map[string]any{"id": "5_10", "project_id": float64(5), "profile_id": float64(10)},
 			want:         "5:10",
 		},
+		"new job-id-only resource (dbtcloud_job_completion_trigger) resolves :id to the downstream job id": {
+			resourceType: "dbtcloud_job_completion_trigger",
+			resourceID:   "456",
+			data:         map[string]any{"id": float64(456)},
+			want:         "456",
+		},
+		"new 3-part composite resource (dbtcloud_environment_variable_job_override) resolves :project_id::job_definition_id::environment_variable_job_override_id": {
+			resourceType: "dbtcloud_environment_variable_job_override",
+			resourceID:   "71_456_789",
+			data: map[string]any{
+				"id":                                   "71_456_789",
+				"project_id":                           float64(71),
+				"job_definition_id":                    float64(456),
+				"environment_variable_job_override_id": float64(789),
+			},
+			want: "71:456:789",
+		},
 	}
 
 	for name, tc := range tests {
@@ -80,14 +97,16 @@ func TestImport_ResolveImportField(t *testing.T) {
 		fallback string
 		want     string
 	}{
-		"numeric field present":     {data: map[string]any{"project_id": float64(71)}, key: "project_id", fallback: "no-project_id", want: "71"},
-		"string field present":      {data: map[string]any{"name": "my-resource"}, key: "name", fallback: "no-name", want: "my-resource"},
-		"field absent":              {data: map[string]any{}, key: "connection_id", fallback: "no-connection_id", want: "no-connection_id"},
-		"field nil":                 {data: map[string]any{"connection_id": nil}, key: "connection_id", fallback: "no-connection_id", want: "no-connection_id"},
-		"field unexpected type":     {data: map[string]any{"repository_id": true}, key: "repository_id", fallback: "no-repository_id", want: "no-repository_id"},
-		"nil data map":              {data: nil, key: "name", fallback: "no-name", want: "no-name"},
-		"user_groups id-as-user_id": {data: map[string]any{"id": float64(42)}, key: "id", fallback: "no-userid", want: "42"},
-		"profile_id field present":  {data: map[string]any{"profile_id": float64(10)}, key: "profile_id", fallback: "no-profile_id", want: "10"},
+		"numeric field present":           {data: map[string]any{"project_id": float64(71)}, key: "project_id", fallback: "no-project_id", want: "71"},
+		"string field present":            {data: map[string]any{"name": "my-resource"}, key: "name", fallback: "no-name", want: "my-resource"},
+		"field absent":                    {data: map[string]any{}, key: "connection_id", fallback: "no-connection_id", want: "no-connection_id"},
+		"field nil":                       {data: map[string]any{"connection_id": nil}, key: "connection_id", fallback: "no-connection_id", want: "no-connection_id"},
+		"field unexpected type":           {data: map[string]any{"repository_id": true}, key: "repository_id", fallback: "no-repository_id", want: "no-repository_id"},
+		"nil data map":                    {data: nil, key: "name", fallback: "no-name", want: "no-name"},
+		"user_groups id-as-user_id":       {data: map[string]any{"id": float64(42)}, key: "id", fallback: "no-userid", want: "42"},
+		"profile_id field present":        {data: map[string]any{"profile_id": float64(10)}, key: "profile_id", fallback: "no-profile_id", want: "10"},
+		"job_definition_id field present": {data: map[string]any{"job_definition_id": float64(456)}, key: "job_definition_id", fallback: "no-job_definition_id", want: "456"},
+		"environment_variable_job_override_id field present": {data: map[string]any{"environment_variable_job_override_id": float64(789)}, key: "environment_variable_job_override_id", fallback: "no-environment_variable_job_override_id", want: "789"},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
 ## Problem
  The generator/importer derived every resource's label and import address
  directly from a numeric or string `structData["id"]`, which only works for
  list-based resources keyed by a per-item id. That left four categories of
  account state unreproducible:

  - singleton with no per-item id at all. Without them, a job that depends on
    a disabled feature (e.g. Advanced CI) fails to create in the target.
  - **Profiles** - the modern binding between a deployment environment and its
    connection + credentials. The generator always emitted the legacy
    `connection_id`/`credential_id`/`extended_attributes_id` trio and never a
    profile resource, mis-binding environments on profile-based accounts.
    Setting `primary_profile_id` alongside the legacy trio is also a hard
    provider error, so the two binding styles can never both be present.
  - **Job completion triggers** - "run after" orchestration. The trigger data
    already rides on a job's own payload but was never reproduced as its own
    resource, so chained jobs silently lost their upstream trigger.
  - **Per-job environment variable overrides** - dropped entirely, so a job
    silently fell back to the environment-level value instead of its intended
    per-job override.

  ## Fix

  1. **`computeResourceLabel`** - extracts the id-derivation logic into one
     function, identical behavior for every existing resource, plus an
     explicit override a resource `case` can set to supply its own label
     instead of deriving one from `structData["id"]`. Adds
     `dbtcloud_account_features` as the first (singleton) consumer.
  2. **`dbtcloud_profile`** - project-scoped, composite id
     (`project_id:profile_id`). Rather than generalizing the override
     mechanism further, composite ids are folded directly into
     `structData["id"]`, reusing a pattern this codebase already used for
     `dbtcloud_environment_variable`. Reworks the `dbtcloud_environment` case
     into an explicit either/or: profile-bound environments emit
     `primary_profile_id` and omit the legacy trio; non-profile environments
     are unchanged.
  3. **`dbtcloud_job_completion_trigger`** and
     **`dbtcloud_environment_variable_job_override`** - both confirmed against
     the real provider schema rather than assumed (the trigger resource has
     flat attributes with no nested `condition` block; the override's value
     attribute is `raw_value`, not `value`). The override's secret-named
     values are externalized to a Terraform variable, mirroring the existing
     `dbtcloud_environment_variable` pattern. Also fixes a related ordering
     hazard: the existing `dbtcloud_job` case mutates each job's
     `job_completion_trigger_condition` field in place, so trigger data is now
     extracted before that mutation can happen - otherwise requesting both
     resource types together in one invocation could silently drop trigger
     data depending on switch-case order.

  Every currently-supported resource type's behavior is unchanged.

  ## Testing

  Build/vet/format, clean on the full branch:
  ```
  $ go build ./...
  $ go vet ./...
  $ gofmt -l .
  (all three: no output, exit 0)
  ```

  All unit tests (30 test functions / 44 sub-tests), all passing:
  ```
  --- PASS: TestGenerate_writeAttrLine (0.00s)
  --- PASS: TestGenerate_ComputeResourceLabel (0.00s)
  --- PASS: TestGenerate_ComputeResourceLabelPanicsOnMissingID (0.00s)
  --- PASS: TestGenerate_AccountFeaturesHCLEmission (0.00s)
  --- PASS: TestGenerate_TransformProfileForGenerate (0.00s)
  --- PASS: TestGenerate_ProfileHCLEmission (0.00s)
  --- PASS: TestGenerate_TransformEnvironmentForGenerate_EitherOr (0.00s)
  --- PASS: TestGenerate_TransformJobCompletionTriggerForGenerate (0.00s)
  --- PASS: TestGenerate_JobCompletionTriggerHCLEmission (0.00s)
  --- PASS: TestGenerate_TransformEnvironmentVariableJobOverrideForGenerate (0.05s)
  --- PASS: TestGenerate_EnvironmentVariableJobOverrideHCLEmission (0.00s)
  --- PASS: TestImport_BuildRawImportAddress (0.00s)
  --- PASS: TestImport_ResolveImportField (0.00s)
  PASS
  ok    github.com/dbt-labs/dbtcloud-terraforming/internal/app/dbtcloud-terraforming/cmd        0.25s
  ```

 Additional tests completed:
  - `TestImport_BuildRawImportAddress` proves an existing numeric-id resource's
    import string is byte-identical to before, alongside all three new id
    shapes (singleton, project-scoped composite, 3-part composite).
  - `TestGenerate_TransformEnvironmentForGenerate_EitherOr` proves a
    profile-bound environment never carries any of the legacy trio and a
    non-profile environment is unchanged.
  - `TestGenerate_EnvironmentVariableJobOverrideHCLEmission`'s secret case
    asserts the literal secret value is **absent** from the emitted HCL, not
    just that a `var.*` reference is present.
  - `TestGenerate_JobCompletionTriggerHCLEmission` asserts no nested
    `condition` block is emitted, matching the real (not assumed) provider
    schema.

  Repo-wide `go test ./...` fails on every branch/commit in this history,
  including unmodified `main`, with an unrelated pre-existing environment
  issue (confirmed via `git stash`):
  ```
  $ go test ./...
  time="..." level=fatal msg="--account/-a or DBT_CLOUD_ACCOUNT_ID must be set"
  FAIL  github.com/dbt-labs/dbtcloud-terraforming/internal/app/dbtcloud-terraforming/cmd        0.395s
  ```

  ## Pending (not blocking)
  Four e2e VCR cassettes (`dbtcloud_account_features`, `dbtcloud_profile`,
  `dbtcloud_job_completion_trigger`, `dbtcloud_environment_variable_job_override`)
  require live account credentials to record and aren't included. Each has a
  scaffolded row in `TestResourceGeneration` with the exact recording command
  in a code comment, and standalone unit coverage in the meantime.